### PR TITLE
Fixes for handling SML and directory related configuration keys

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPSettingsManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPSettingsManagerMongoDB.java
@@ -77,16 +77,21 @@ public class SMPSettingsManagerMongoDB extends AbstractManagerMongoDB implements
   public static void toDomain (@Nonnull final Document aDoc, @Nonnull final SMPSettings aTarget)
   {
     aTarget.setRESTWritableAPIDisabled (aDoc.getBoolean (BSON_SMP_REST_WRITABLE_API_DISABLED,
-                                                         SMPSettings.DEFAULT_SMP_REST_WRITABLE_API_DISABLED));
-    aTarget.setDirectoryIntegrationRequired (aDoc.getBoolean (BSON_DIRECTORY_INTEGRATION_REQUIRED,
-                                                              SMPSettings.DEFAULT_SMP_DIRECTORY_INTEGRATION_REQUIRED));
+                                                         aTarget.isRESTWritableAPIDisabled ()));
     aTarget.setDirectoryIntegrationEnabled (aDoc.getBoolean (BSON_DIRECTORY_INTEGRATION_ENABLED,
-                                                             SMPSettings.DEFAULT_SMP_DIRECTORY_INTEGRATION_ENABLED));
+                                                             aTarget.isDirectoryIntegrationEnabled ()));
+    aTarget.setDirectoryIntegrationRequired (aDoc.getBoolean (BSON_DIRECTORY_INTEGRATION_REQUIRED,
+                                                              aTarget.isDirectoryIntegrationRequired ()));
     aTarget.setDirectoryIntegrationAutoUpdate (aDoc.getBoolean (BSON_DIRECTORY_INTEGRATION_AUTO_UPDATE,
-                                                                SMPSettings.DEFAULT_SMP_DIRECTORY_INTEGRATION_AUTO_UPDATE));
-    aTarget.setDirectoryHostName (aDoc.getString (BSON_DIRECTORY_HOSTNAME));
-    aTarget.setSMLRequired (aDoc.getBoolean (BSON_SML_REQUIRED, SMPSettings.DEFAULT_SML_REQUIRED));
-    aTarget.setSMLEnabled (aDoc.getBoolean (BSON_SML_ENABLED, SMPSettings.DEFAULT_SML_ENABLED));
+                                                                aTarget.isDirectoryIntegrationAutoUpdate ()));
+    String sDirectoryHostName = aDoc.getString (BSON_DIRECTORY_HOSTNAME);
+    if (sDirectoryHostName == null)
+    {
+      sDirectoryHostName = aTarget.getDirectoryHostName ();
+    }
+    aTarget.setDirectoryHostName (sDirectoryHostName);
+    aTarget.setSMLEnabled (aDoc.getBoolean (BSON_SML_ENABLED, aTarget.isSMLEnabled ()));
+    aTarget.setSMLRequired (aDoc.getBoolean (BSON_SML_REQUIRED, aTarget.isSMLRequired ()));
     aTarget.setSMLInfoID (aDoc.getString (BSON_SML_INFO_ID));
   }
 
@@ -100,7 +105,7 @@ public class SMPSettingsManagerMongoDB extends AbstractManagerMongoDB implements
   }
 
   @Nonnull
-  @ReturnsMutableObject
+  @aTargeturnsMutableObject
   public final CallbackList <ISMPSettingsCallback> callbacks ()
   {
     return m_aCallbacks;

--- a/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPSettingsManagerJDBC.java
+++ b/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPSettingsManagerJDBC.java
@@ -186,18 +186,23 @@ public class SMPSettingsManagerJDBC extends AbstractJDBCEnabledManager implement
       // Queries DB
       final ICommonsMap <String, String> aValues = aMgr.getAllSettingsValuesFromDB ();
 
-      final SMPSettings ret = new SMPSettings (false);
+      final SMPSettings ret = new SMPSettings (true);
       ret.setRESTWritableAPIDisabled (StringParser.parseBool (aValues.get (SMP_REST_WRITABLE_API_DISABLED),
-                                                              SMPSettings.DEFAULT_SMP_REST_WRITABLE_API_DISABLED));
+                                                              ret.isRESTWritableAPIDisabled ()));
       ret.setDirectoryIntegrationEnabled (StringParser.parseBool (aValues.get (DIRECTORY_INTEGRATION_ENABLED),
-                                                                  SMPSettings.DEFAULT_SMP_DIRECTORY_INTEGRATION_ENABLED));
+                                                                  ret.isDirectoryIntegrationEnabled ()));
       ret.setDirectoryIntegrationRequired (StringParser.parseBool (aValues.get (DIRECTORY_INTEGRATION_REQUIRED),
-                                                                   SMPSettings.DEFAULT_SMP_DIRECTORY_INTEGRATION_REQUIRED));
+                                                                   ret.isDirectoryIntegrationRequired ()));
       ret.setDirectoryIntegrationAutoUpdate (StringParser.parseBool (aValues.get (DIRECTORY_INTEGRATION_AUTO_UPDATE),
-                                                                     SMPSettings.DEFAULT_SMP_DIRECTORY_INTEGRATION_AUTO_UPDATE));
-      ret.setDirectoryHostName (aValues.get (DIRECTORY_HOSTNAME));
-      ret.setSMLEnabled (StringParser.parseBool (aValues.get (SML_ENABLED), SMPSettings.DEFAULT_SML_ENABLED));
-      ret.setSMLRequired (StringParser.parseBool (aValues.get (SML_REQUIRED), SMPSettings.DEFAULT_SML_REQUIRED));
+                                                                     ret.isDirectoryIntegrationAutoUpdate ()));
+      String sDirectoryHostName = aValues.get (DIRECTORY_HOSTNAME);
+      if (sDirectoryHostName == null)
+      {
+        sDirectoryHostName = ret.getDirectoryHostName ();
+      }
+      ret.setDirectoryHostName (sDirectoryHostName);
+      ret.setSMLEnabled (StringParser.parseBool (aValues.get (SML_ENABLED), ret.isSMLEnabled ()));
+      ret.setSMLRequired (StringParser.parseBool (aValues.get (SML_REQUIRED), ret.isSMLRequired ()));
       ret.setSMLInfoID (aValues.get (SML_INFO_ID));
       return ret;
     }

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/settings/SMPSettings.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/settings/SMPSettings.java
@@ -146,24 +146,24 @@ public class SMPSettings implements ISMPSettings
 
   public boolean isSMLRequired ()
   {
-    return m_aSettings.getAsBoolean (KEY_SML_REQUIRED_OLD, DEFAULT_SML_REQUIRED);
+    return m_aSettings.getAsBoolean (KEY_SML_REQUIRED, DEFAULT_SML_REQUIRED);
   }
 
   @Nonnull
   public EChange setSMLRequired (final boolean bSMLRequired)
   {
-    return m_aSettings.putIn (KEY_SML_REQUIRED_OLD, bSMLRequired);
+    return m_aSettings.putIn (KEY_SML_REQUIRED, bSMLRequired);
   }
 
   public boolean isSMLEnabled ()
   {
-    return m_aSettings.getAsBoolean (KEY_SML_ENABLED_OLD, DEFAULT_SML_ENABLED);
+    return m_aSettings.getAsBoolean (KEY_SML_ENABLED, DEFAULT_SML_ENABLED);
   }
 
   @Nonnull
   public EChange setSMLEnabled (final boolean bSMLEnabled)
   {
-    return m_aSettings.putIn (KEY_SML_ENABLED_OLD, bSMLEnabled);
+    return m_aSettings.putIn (KEY_SML_ENABLED, bSMLEnabled);
   }
 
   @Nullable
@@ -188,52 +188,52 @@ public class SMPSettings implements ISMPSettings
 
   public boolean isDirectoryIntegrationRequired ()
   {
-    return m_aSettings.getAsBoolean (KEY_SMP_DIRECTORY_INTEGRATION_REQUIRED_OLD,
+    return m_aSettings.getAsBoolean (KEY_SMP_DIRECTORY_INTEGRATION_REQUIRED,
                                      DEFAULT_SMP_DIRECTORY_INTEGRATION_REQUIRED);
   }
 
   @Nonnull
   public EChange setDirectoryIntegrationRequired (final boolean bPeppolDirectoryIntegrationRequired)
   {
-    return m_aSettings.putIn (KEY_SMP_DIRECTORY_INTEGRATION_REQUIRED_OLD, bPeppolDirectoryIntegrationRequired);
+    return m_aSettings.putIn (KEY_SMP_DIRECTORY_INTEGRATION_REQUIRED, bPeppolDirectoryIntegrationRequired);
   }
 
   public boolean isDirectoryIntegrationEnabled ()
   {
-    return m_aSettings.getAsBoolean (KEY_SMP_DIRECTORY_INTEGRATION_ENABLED_OLD,
+    return m_aSettings.getAsBoolean (KEY_SMP_DIRECTORY_INTEGRATION_ENABLED,
                                      DEFAULT_SMP_DIRECTORY_INTEGRATION_ENABLED);
   }
 
   @Nonnull
   public EChange setDirectoryIntegrationEnabled (final boolean bPeppolDirectoryIntegrationEnabled)
   {
-    return m_aSettings.putIn (KEY_SMP_DIRECTORY_INTEGRATION_ENABLED_OLD, bPeppolDirectoryIntegrationEnabled);
+    return m_aSettings.putIn (KEY_SMP_DIRECTORY_INTEGRATION_ENABLED, bPeppolDirectoryIntegrationEnabled);
   }
 
   public boolean isDirectoryIntegrationAutoUpdate ()
   {
-    return m_aSettings.getAsBoolean (KEY_SMP_DIRECTORY_INTEGRATION_AUTO_UPDATE_OLD,
+    return m_aSettings.getAsBoolean (KEY_SMP_DIRECTORY_INTEGRATION_AUTO_UPDATE,
                                      DEFAULT_SMP_DIRECTORY_INTEGRATION_AUTO_UPDATE);
   }
 
   @Nonnull
   public EChange setDirectoryIntegrationAutoUpdate (final boolean bPeppolDirectoryIntegrationAutoUpdate)
   {
-    return m_aSettings.putIn (KEY_SMP_DIRECTORY_INTEGRATION_AUTO_UPDATE_OLD, bPeppolDirectoryIntegrationAutoUpdate);
+    return m_aSettings.putIn (KEY_SMP_DIRECTORY_INTEGRATION_AUTO_UPDATE, bPeppolDirectoryIntegrationAutoUpdate);
   }
 
   @Nonnull
   public String getDirectoryHostName ()
   {
     // TODO select between test and prod in default
-    return m_aSettings.getAsString (KEY_SMP_DIRECTORY_HOSTNAME_OLD,
+    return m_aSettings.getAsString (KEY_SMP_DIRECTORY_HOSTNAME,
                                     true ? DEFAULT_SMP_DIRECTORY_HOSTNAME_PROD : DEFAULT_SMP_DIRECTORY_HOSTNAME_TEST);
   }
 
   @Nonnull
   public EChange setDirectoryHostName (@Nullable final String sDirectoryHostName)
   {
-    return m_aSettings.putIn (KEY_SMP_DIRECTORY_HOSTNAME_OLD, sDirectoryHostName);
+    return m_aSettings.putIn (KEY_SMP_DIRECTORY_HOSTNAME, sDirectoryHostName);
   }
 
   @Nonnull

--- a/phoss-smp-webapp-mongodb/src/main/resources/application.properties
+++ b/phoss-smp-webapp-mongodb/src/main/resources/application.properties
@@ -122,22 +122,22 @@ smp.forceroot = true
 #smp.publicurl = http://smp.example.org/
 
 # Is an SML needed in the current scenario - show warnings if true
-sml.required=true
+#sml.required=true
 
 ## Write to SML? true or false
-sml.enabled=false
+#sml.enabled=false
 
 # The SMP ID also used in the SML!
 sml.smpid=TEST-SMP-ID1
 
-# SML connection timeout milliseconds 
+# SML connection timeout milliseconds
 #sml.connection.timeout.ms = 5000
 
 # SML request timeout milliseconds
 #sml.request.timeout.ms = 20000
 
 # Enable Directory integration?
-smp.directory.integration.enabled=true
+#smp.directory.integration.enabled=true
 
 # Use PEPPOL identifiers (with all constraints) or simple, unchecked identifiers?
 # Possible values are "peppol", "simple" and "bdxr"
@@ -162,8 +162,8 @@ smp.rest.payload.on.error=true
 #https.proxyHost = 10.0.0.10
 #https.proxyPort = 8080
 # Credentials for the proxy server (if needed)
-#proxy.username = 
-#proxy.password = 
+#proxy.username =
+#proxy.password =
 
 # MongoDB specific settings
 mongodb.connectionstring = mongodb://localhost

--- a/phoss-smp-webapp-sql/src/main/resources/application.properties
+++ b/phoss-smp-webapp-sql/src/main/resources/application.properties
@@ -121,22 +121,22 @@ smp.forceroot = true
 #smp.publicurl = http://smp.example.org/
 
 # Is an SML needed in the current scenario - show warnings if true
-sml.required=true
+#sml.required=true
 
 ## Write to SML? true or false
-sml.enabled=false
+#sml.enabled=false
 
 # The SMP ID also used in the SML!
 sml.smpid=TEST-SMP-ID1
 
-# SML connection timeout milliseconds 
+# SML connection timeout milliseconds
 #sml.connection.timeout.ms = 5000
 
 # SML request timeout milliseconds
 #sml.request.timeout.ms = 20000
 
 # Enable Directory integration?
-smp.directory.integration.enabled=true
+#smp.directory.integration.enabled=true
 
 # Use PEPPOL identifiers (with all constraints) or simple, unchecked identifiers?
 # Possible values are "peppol", "simple" and "bdxr"
@@ -161,8 +161,8 @@ smp.rest.payload.on.error=true
 #https.proxyHost = 10.0.0.10
 #https.proxyPort = 8080
 # Credentials for the proxy server (if needed)
-#proxy.username = 
-#proxy.password = 
+#proxy.username =
+#proxy.password =
 
 ## Required when using the SQL backend
 

--- a/phoss-smp-webapp-xml/src/main/resources/application.properties
+++ b/phoss-smp-webapp-xml/src/main/resources/application.properties
@@ -120,22 +120,22 @@ smp.forceroot = true
 #smp.publicurl = http://smp.example.org/
 
 # Is an SML needed in the current scenario - show warnings if true
-sml.required=true
+#sml.required=true
 
 ## Write to SML? true or false
-sml.enabled=false
+#sml.enabled=false
 
 # The SMP ID also used in the SML!
 sml.smpid=TEST-SMP-ID1
 
-# SML connection timeout milliseconds 
+# SML connection timeout milliseconds
 #sml.connection.timeout.ms = 5000
 
 # SML request timeout milliseconds
 #sml.request.timeout.ms = 20000
 
 # Enable Directory integration?
-smp.directory.integration.enabled=true
+#smp.directory.integration.enabled=true
 
 # Use PEPPOL identifiers (with all constraints) or simple, unchecked identifiers?
 # Possible values are "peppol", "simple" and "bdxr"
@@ -160,5 +160,5 @@ smp.rest.payload.on.error=true
 #https.proxyHost = 10.0.0.10
 #https.proxyPort = 8080
 # Credentials for the proxy server (if needed)
-#proxy.username = 
-#proxy.password = 
+#proxy.username =
+#proxy.password =


### PR DESCRIPTION
While configuring a new instance of the latest (7.1.0) SQL version I noticed that some properties from the configuration files were not taken into account and always needed to be changed via the settings UI.

Looking closer into the issue I noticed a few problems:
- When reading the SML/Directory related configuration values from the DB the fallback will be the hardcoded values, not the ones from the config file
- The `application.properties` resource shipped within the app had the new keys define that prevented the old keys from being read

This PR fixes these by:

- Fallback to set config values instead of constants when reading settings from DB
- Use the new config keys when reading the SML/Directory related values
- Disable the SML/Directory related values from the default application.properties


