### PR TITLE
Fix missing slash in ServiceMetadataReference href

### DIFF
--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestDataProvider.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestDataProvider.java
@@ -277,6 +277,7 @@ public class SMPRestDataProvider implements ISMPServerAPIDataProvider
            m_sQueryPathPrefix +
            aServiceGroupID.getURIPercentEncoded () +
            SMPRestFilter.PATH_SERVICES +
+           "/" +
            aDocTypeID.getURIPercentEncoded ();
   }
 }


### PR DESCRIPTION
## Problem

Since v8.1.0, the `ServiceMetadataReference` `href` attributes in the `ServiceGroup` XML response are missing a `/` between `services` and the Document Type Identifier.

**Broken URL:**
```
https://smp.example.com/iso6523-actorid-upis%3A%3A9915%3Atest/servicesbusdox-docid-qns%3A%3Aurn%3A...
```

**Expected URL:**
```
https://smp.example.com/iso6523-actorid-upis%3A%3A9915%3Atest/services/busdox-docid-qns%3A%3Aurn%3A...
```

## Root Cause

In `SMPRestFilter.java`, the constant `PATH_SERVICES` was changed from `"/services/"` to `"/services"` (trailing slash removed) between v8.0.17 and v8.1.0.

`SMPRestDataProvider.getServiceMetadataReferenceHref()` concatenates `PATH_SERVICES` directly with the document type ID, resulting in `servicesbusdox-docid-qns` instead of `services/busdox-docid-qns`.

## Fix

Added an explicit `"/"` separator between `PATH_SERVICES` and the document type ID in `getServiceMetadataReferenceHref()`.

## Impact

Without this fix, any SMP client following the `href` from the `ServiceGroup` response to resolve `ServiceMetadata` gets a 404 due to the malformed URL path.f