### PR TITLE
Run maintained Docker images on JDK 25

### DIFF
--- a/docker/Dockerfile-release-binary-mongodb
+++ b/docker/Dockerfile-release-binary-mongodb
@@ -35,7 +35,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-release-binary-sql
+++ b/docker/Dockerfile-release-binary-sql
@@ -35,7 +35,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-release-binary-xml
+++ b/docker/Dockerfile-release-binary-xml
@@ -35,7 +35,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-release-from-source-xml
+++ b/docker/Dockerfile-release-from-source-xml
@@ -36,7 +36,7 @@ RUN echo Building phoss SMP $SMP_VERSION \
 
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-snapshot-from-local-source-sql
+++ b/docker/Dockerfile-snapshot-from-local-source-sql
@@ -16,7 +16,7 @@
 #
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom -Dorg.apache.catalina.session.StandardSession.ACTIVITY_CHECK=true"

--- a/docker/Dockerfile-snapshot-from-source-mongodb
+++ b/docker/Dockerfile-snapshot-from-source-mongodb
@@ -16,7 +16,7 @@
 #
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-snapshot-from-source-sql
+++ b/docker/Dockerfile-snapshot-from-source-sql
@@ -16,7 +16,7 @@
 #
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-snapshot-from-source-xml
+++ b/docker/Dockerfile-snapshot-from-source-xml
@@ -16,7 +16,7 @@
 #
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk21
+FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # phoss SMP Docker configuration
 
 This folder contains the Docker configuration files for phoss SMP.
-It is based on the official `tomcat:10.1-jdk17` image since v7.0.0.
+It is based on the official `tomcat:10.1-jdk25` image.
 It is recommended to run production Docker images with at least 4GB of RAM.
 
 Prebuild images are available from:


### PR DESCRIPTION
## Summary

- move all maintained release and snapshot Tomcat runtime stages from JDK 21 to JDK 25
- update the Docker README to reflect the actual runtime baseline
- retain Java 17 source and target compatibility

## Validation

- built Dockerfile-release-binary-sql with SMP_VERSION=8.1.8
- verified the resulting image reports OpenJDK 25.0.3 LTS
- confirmed all eight maintained Dockerfiles now use tomcat:10.1-jdk25

Fixes #496