### PR TITLE
Fix release-from-source Docker toolchain

### DIFF
--- a/docker/Dockerfile-release-from-source-xml
+++ b/docker/Dockerfile-release-from-source-xml
@@ -15,13 +15,7 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk:11-hotspot AS build
-
-# Install git and maven
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y git maven \
-  && rm -rf /var/lib/apt/lists/*
+FROM maven:3.9-eclipse-temurin-17 AS build
 
 ARG SMP_VERSION
 


### PR DESCRIPTION
## Summary

- replace the obsolete Java 11 builder with Maven 3.9 on Eclipse Temurin 17
- remove the redundant apt-installed Maven and Git toolchain
- leave the runtime stage and resulting application layout unchanged

## Validation

A clean build of Dockerfile-release-from-source-xml with SMP_VERSION=8.1.8 completed successfully. The complete nine-module Maven reactor built inside the image before the XML web application was copied into the runtime stage.

Fixes #497