### PR TITLE
Count all endpoints in SMPProcess

### DIFF
--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/serviceinfo/SMPProcess.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/serviceinfo/SMPProcess.java
@@ -70,7 +70,10 @@ public class SMPProcess extends AbstractSMPHasExtension implements ISMPProcess
   @Nonnegative
   public int getEndpointCount ()
   {
-    return m_aEndpoints.size ();
+    int ret = 0;
+    for (final var aEndpoints : m_aEndpoints.values ())
+      ret += aEndpoints.size ();
+    return ret;
   }
 
   @Nullable

--- a/phoss-smp-backend/src/test/java/com/helger/phoss/smp/domain/serviceinfo/SMPProcessEndpointCountTest.java
+++ b/phoss-smp-backend/src/test/java/com/helger/phoss/smp/domain/serviceinfo/SMPProcessEndpointCountTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * The Original Code is Copyright The Peppol project (http://www.peppol.eu)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.helger.phoss.smp.domain.serviceinfo;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.helger.peppolid.peppol.PeppolIdentifierHelper;
+import com.helger.peppolid.simple.process.SimpleProcessIdentifier;
+
+/**
+ * Test class for {@link SMPProcess#getEndpointCount()}.
+ *
+ * @author Greg Taube
+ */
+public final class SMPProcessEndpointCountTest
+{
+  private static SMPEndpoint _createEndpoint (final String sID, final String sTransportProfile)
+  {
+    return new SMPEndpoint (sID,
+                            sTransportProfile,
+                            "http://localhost/as2",
+                            false,
+                            null,
+                            null,
+                            null,
+                            "cert",
+                            "description",
+                            "https://example.org/contact",
+                            null,
+                            null);
+  }
+
+  @Test
+  public void testMultipleEndpointsPerTransportProfile ()
+  {
+    final SMPProcess aProcess = new SMPProcess (new SimpleProcessIdentifier (PeppolIdentifierHelper.DEFAULT_PROCESS_SCHEME,
+                                                                             "test-process"),
+                                                null,
+                                                null);
+    aProcess.addEndpoint (_createEndpoint ("endpoint-1", "transport-profile-1"));
+    aProcess.addEndpoint (_createEndpoint ("endpoint-2", "transport-profile-1"));
+    aProcess.addEndpoint (_createEndpoint ("endpoint-3", "transport-profile-2"));
+
+    assertEquals (3, aProcess.getEndpointCount ());
+  }
+}


### PR DESCRIPTION
## Summary

- make SMPProcess.getEndpointCount sum the endpoint lists instead of counting transport-profile map keys
- add a regression test with two endpoints sharing one profile and a third using another profile

## Validation

mvn --batch-mode --no-transfer-progress -pl phoss-smp-backend -am test

Result: 27 tests run, 0 failures, 0 errors, 1 existing skipped test.

Fixes #498