### PR TITLE
Initialize CATALINA_OPTS before appending Docker options

### DIFF
--- a/docker/Dockerfile-release-binary-mongodb
+++ b/docker/Dockerfile-release-binary-mongodb
@@ -38,7 +38,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-release-binary-sql
+++ b/docker/Dockerfile-release-binary-sql
@@ -38,7 +38,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-release-binary-xml
+++ b/docker/Dockerfile-release-binary-xml
@@ -38,7 +38,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-release-from-source-xml
+++ b/docker/Dockerfile-release-from-source-xml
@@ -39,7 +39,7 @@ RUN echo Building phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-snapshot-from-local-source-sql
+++ b/docker/Dockerfile-snapshot-from-local-source-sql
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom -Dorg.apache.catalina.session.StandardSession.ACTIVITY_CHECK=true"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom -Dorg.apache.catalina.session.StandardSession.ACTIVITY_CHECK=true"
 
 # MinRAMPercentage - for low memory containers (<250MB)
 # MaxRAMPercentage - for large memory containers (>250MB)

--- a/docker/Dockerfile-snapshot-from-source-mongodb
+++ b/docker/Dockerfile-snapshot-from-source-mongodb
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-snapshot-from-source-sql
+++ b/docker/Dockerfile-snapshot-from-source-sql
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-snapshot-from-source-xml
+++ b/docker/Dockerfile-snapshot-from-source-xml
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk21
 
 # Use non-blocking random
-ENV CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
@@ -31,7 +31,7 @@ RUN  sed -i 's/<Connector port="8080" protocol="HTTP\/1.1"/<Connector port="8080
 # MinRAMPercentage - for low memory containers (<250MB)
 # MaxRAMPercentage - for large memory containers (>250MB)
 # See: https://medium.com/pernod-ricard-tech/how-to-control-java-memory-in-tomcat-running-on-docker-cec267f858d4
-ENV CATALINA_OPTS="-XX:InitialRAMPercentage=10 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"
+ENV CATALINA_OPTS="$CATALINA_OPTS -XX:InitialRAMPercentage=10 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"
 
 LABEL vendor="Philip Helger"
 LABEL version="HEAD"


### PR DESCRIPTION
## Summary

- initialize CATALINA_OPTS before later Docker ENV instructions append to it
- preserve the entropy option in the XML snapshot image when memory options are added
- apply the same option composition to all eight maintained Dockerfiles

## Validation

- Docker build checks pass for all eight maintained Dockerfiles with no warnings
- a complete SMP 8.1.8 SQL release-image build finishes without the prior UndefinedVar warning

Fixes #500