### PR TITLE
Enable native access for Tomcat on JDK 25

### DIFF
--- a/docker/Dockerfile-release-binary-mongodb
+++ b/docker/Dockerfile-release-binary-mongodb
@@ -38,7 +38,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-release-binary-sql
+++ b/docker/Dockerfile-release-binary-sql
@@ -38,7 +38,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-release-binary-xml
+++ b/docker/Dockerfile-release-binary-xml
@@ -38,7 +38,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-release-from-source-xml
+++ b/docker/Dockerfile-release-from-source-xml
@@ -33,7 +33,7 @@ RUN echo Building phoss SMP $SMP_VERSION \
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-snapshot-from-local-source-sql
+++ b/docker/Dockerfile-snapshot-from-local-source-sql
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom -Dorg.apache.catalina.session.StandardSession.ACTIVITY_CHECK=true"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom -Dorg.apache.catalina.session.StandardSession.ACTIVITY_CHECK=true"
 
 # MinRAMPercentage - for low memory containers (<250MB)
 # MaxRAMPercentage - for large memory containers (>250MB)

--- a/docker/Dockerfile-snapshot-from-source-mongodb
+++ b/docker/Dockerfile-snapshot-from-source-mongodb
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-snapshot-from-source-sql
+++ b/docker/Dockerfile-snapshot-from-source-sql
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/docker/Dockerfile-snapshot-from-source-xml
+++ b/docker/Dockerfile-snapshot-from-source-xml
@@ -19,7 +19,7 @@
 FROM tomcat:10.1-jdk25
 
 # Use non-blocking random
-ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"
+ENV CATALINA_OPTS="--enable-native-access=ALL-UNNAMED -Djava.security.egd=file:/dev/urandom"
 
 # Special encoded slash handling for SMP
 #   Tomcat 10 removed: org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true


### PR DESCRIPTION
Closes #506.

The JDK 25 Docker images load Tomcat Native through org.apache.tomcat.jni.Library. Without an explicit native-access grant, JDK 25 warns that this restricted call will be blocked by a future release.

This adds the launcher option requested by the JVM to all eight Tomcat/JDK 25 release and snapshot Dockerfiles. It does not change the application, Tomcat Native, OpenSSL, or memory settings.

Verification:
- Docker build check passes without warnings for the SQL release Dockerfile.
- All Dockerfiles based on tomcat:10.1-jdk25 contain the option.
- PHOSS SMP 8.1.8 was run on Tomcat 10.1.57 / Temurin 25.0.3 against PostgreSQL 18: all 34 migrations completed, /public returned HTTP 200, and the restricted-native-access warning disappeared.