### PR TITLE
Use JRE 25 for release Docker images

### DIFF
--- a/docker/Dockerfile-release-binary-mongodb
+++ b/docker/Dockerfile-release-binary-mongodb
@@ -35,7 +35,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk25
+FROM tomcat:10.1-jre25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-release-binary-sql
+++ b/docker/Dockerfile-release-binary-sql
@@ -35,7 +35,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk25
+FROM tomcat:10.1-jre25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"

--- a/docker/Dockerfile-release-binary-xml
+++ b/docker/Dockerfile-release-binary-xml
@@ -35,7 +35,7 @@ RUN echo Downloading phoss SMP $SMP_VERSION \
 
 
 # Use an official Tomcat runtime as a base image
-FROM tomcat:10.1-jdk25
+FROM tomcat:10.1-jre25
 
 # Use non-blocking random
 ENV CATALINA_OPTS="-Djava.security.egd=file:/dev/urandom"


### PR DESCRIPTION
Closes #508.

The official release images receive an already-built WAR from their build stage, so their final Tomcat stage needs a Java runtime but not the JDK toolchain. This changes only the three release-binary Dockerfiles used by `docker/build-all.sh`; the snapshot-from-source images retain the JDK because they run Maven.

For current Linux/amd64 Tomcat 10.1 images this reduces compressed base-image data by 35,672,971 bytes (22.7%) per published image.

Validation:
- built XML, SQL, and MongoDB 8.1.8 images for Linux/amd64
- each reports Temurin 25.0.3
- `javac` is absent from each final image
- independently ran the SQL webapp on the JRE image against fresh PostgreSQL: all 34 migrations completed and `/public` returned HTTP 200

This is intentionally separate from #507 so each runtime change can be reviewed independently.