### PR TITLE
Fix standalone Jetty stop port mismatch

### DIFF
--- a/phoss-smp-webapp-mongodb/src/test/java/com/helger/phoss/smp/standalone/RunInJettySMPSERVER_MONGODB.java
+++ b/phoss-smp-webapp-mongodb/src/test/java/com/helger/phoss/smp/standalone/RunInJettySMPSERVER_MONGODB.java
@@ -38,7 +38,7 @@ public final class RunInJettySMPSERVER_MONGODB
       throw new IllegalStateException ("Please make sure your working directory is the directory containing 'pom.xml'");
 
     new JettyStarter (RunInJettySMPSERVER_MONGODB.class).setPort (90)
-                                                        .setStopPort (x -> x + 1000)
+                                                        .setStopPort (8090)
                                                         .setSessionCookieName ("SMPSESSION")
                                                         .run ();
   }

--- a/phoss-smp-webapp-sql/src/test/java/com/helger/phoss/smp/standalone/RunInJettySMPSERVER_SQL.java
+++ b/phoss-smp-webapp-sql/src/test/java/com/helger/phoss/smp/standalone/RunInJettySMPSERVER_SQL.java
@@ -38,7 +38,7 @@ public final class RunInJettySMPSERVER_SQL
       throw new IllegalStateException ("Please make sure your working directory is the directory containing 'pom.xml'");
 
     new JettyStarter (RunInJettySMPSERVER_SQL.class).setPort (90)
-                                                    .setStopPort (x -> x + 1000)
+                                                    .setStopPort (8090)
                                                     .setSessionCookieName ("SMPSESSION")
                                                     .run ();
   }

--- a/phoss-smp-webapp-xml/src/test/java/com/helger/phoss/smp/standalone/RunInJettySMPSERVER_XML.java
+++ b/phoss-smp-webapp-xml/src/test/java/com/helger/phoss/smp/standalone/RunInJettySMPSERVER_XML.java
@@ -37,7 +37,7 @@ public final class RunInJettySMPSERVER_XML
       throw new IllegalStateException ("Please make sure your working directory is the directory containing 'pom.xml'");
 
     new JettyStarter (RunInJettySMPSERVER_XML.class).setPort (90)
-                                                    .setStopPort (x -> x + 1000)
+                                                    .setStopPort (8090)
                                                     .setSessionCookieName ("SMPSESSION")
                                                     // .setContextPath ("/smp")
                                                     .run ();


### PR DESCRIPTION
## Summary

- use the explicit stop port 8090 in the XML, SQL, and MongoDB standalone Jetty starters
- align each starter with its existing JettyStopSMPSERVER counterpart
- allow the documented stopper applications to shut down the development server correctly

## Problem

The standalone starters run the HTTP server on port 90 and currently derive the stop port with x -> x + 1000. With the current JettyStarter implementation this resolves to port 1090, while all three stopper classes connect to port 8090. The stopper therefore cannot reach the running server and a stale stop-monitor socket can block a later restart.

Using the explicit port 8090 removes the mismatch and preserves the existing stopper configuration.

## Verification

- mvn -pl phoss-smp-webapp-xml,phoss-smp-webapp-sql,phoss-smp-webapp-mongodb -am -DskipTests test-compile
- mvn -pl phoss-smp-webapp-sql -am test
- manually started RunInJettySMPSERVER_SQL and confirmed the startup log reported Jetty:90:8090
- confirmed GET /ping/ returned HTTP 200
- ran JettyStopSMPSERVER_SQL and confirmed it connected to port 8090 and shut down both listeners