### PR TITLE
Test builds on Java 26

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 17, 21, 25 ]
+        java: [ 17, 21, 25, 26 ]
     name: Java ${{ matrix.java }} build
 
     services:


### PR DESCRIPTION
## Summary

- add Java 26 to the Maven CI matrix
- retain Java 17 source/target compatibility
- retain snapshot deployment on Java 17 only

This gives the current tip immediate Java 26 compatibility coverage while the official Tomcat JRE 26 base-image work discussed in #515 is pending.

## Validation

- `mvn --batch-mode --update-snapshots -DskipTests install` succeeds across all nine modules on OpenJDK 26.0.2
- the PR workflow provisions MySQL 8 and MongoDB 8 and will run the full test suite on Java 26

Related to #515.