### PR TITLE
Pin Ubuntu 24.04 in release Docker build stages

### DIFF
--- a/docker/Dockerfile-release-binary-mongodb
+++ b/docker/Dockerfile-release-binary-mongodb
@@ -15,12 +15,11 @@
 # limitations under the License.
 #
 
-FROM --platform=$BUILDPLATFORM ubuntu:latest AS build
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS build
 
-# Install unzip
+# wget and unzip only - this stage is discarded after the WAR is copied
 RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y wget unzip \
+  && apt-get install -y --no-install-recommends ca-certificates wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ARG SMP_VERSION
@@ -29,7 +28,7 @@ ARG SMP_VERSION
 # Unzip the WAR file to /smp
 # Remove the default "application.properties" file to avoid invalid default configuration
 RUN echo Downloading phoss SMP $SMP_VERSION \
-  && wget -nv https://github.com/phax/phoss-smp/releases/download/phoss-smp-parent-pom-$SMP_VERSION/phoss-smp-webapp-mongodb-$SMP_VERSION.war -O smp.zip \ 
+  && wget -nv https://github.com/phax/phoss-smp/releases/download/phoss-smp-parent-pom-$SMP_VERSION/phoss-smp-webapp-mongodb-$SMP_VERSION.war -O smp.zip \
   && unzip smp.zip -d /smp \
   && rm /smp/WEB-INF/classes/application.properties
 

--- a/docker/Dockerfile-release-binary-mongodb
+++ b/docker/Dockerfile-release-binary-mongodb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS build
+FROM --platform=$BUILDPLATFORM ubuntu:latest AS build
 
 # wget and unzip only - this stage is discarded after the WAR is copied
 RUN apt-get update \

--- a/docker/Dockerfile-release-binary-sql
+++ b/docker/Dockerfile-release-binary-sql
@@ -15,12 +15,11 @@
 # limitations under the License.
 #
 
-FROM --platform=$BUILDPLATFORM ubuntu:latest AS build
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS build
 
-# Install wget and unzip
+# wget and unzip only - this stage is discarded after the WAR is copied
 RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y wget unzip \
+  && apt-get install -y --no-install-recommends ca-certificates wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ARG SMP_VERSION
@@ -29,7 +28,7 @@ ARG SMP_VERSION
 # Unzip the WAR file to /smp
 # Remove the default "application.properties" file to avoid invalid default configuration
 RUN echo Downloading phoss SMP $SMP_VERSION \
-  && wget -nv https://github.com/phax/phoss-smp/releases/download/phoss-smp-parent-pom-$SMP_VERSION/phoss-smp-webapp-sql-$SMP_VERSION.war -O smp.zip \ 
+  && wget -nv https://github.com/phax/phoss-smp/releases/download/phoss-smp-parent-pom-$SMP_VERSION/phoss-smp-webapp-sql-$SMP_VERSION.war -O smp.zip \
   && unzip smp.zip -d /smp \
   && rm /smp/WEB-INF/classes/application.properties
 

--- a/docker/Dockerfile-release-binary-sql
+++ b/docker/Dockerfile-release-binary-sql
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS build
+FROM --platform=$BUILDPLATFORM ubuntu:latest AS build
 
 # wget and unzip only - this stage is discarded after the WAR is copied
 RUN apt-get update \

--- a/docker/Dockerfile-release-binary-xml
+++ b/docker/Dockerfile-release-binary-xml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS build
+FROM --platform=$BUILDPLATFORM ubuntu:latest AS build
 
 # wget and unzip only - this stage is discarded after the WAR is copied
 RUN apt-get update \

--- a/docker/Dockerfile-release-binary-xml
+++ b/docker/Dockerfile-release-binary-xml
@@ -15,12 +15,11 @@
 # limitations under the License.
 #
 
-FROM --platform=$BUILDPLATFORM ubuntu:latest AS build
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS build
 
-# Install wget and unzip
+# wget and unzip only - this stage is discarded after the WAR is copied
 RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y wget unzip \
+  && apt-get install -y --no-install-recommends ca-certificates wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ARG SMP_VERSION
@@ -29,7 +28,7 @@ ARG SMP_VERSION
 # Unzip the WAR file to /smp
 # Remove the default "application.properties" file to avoid invalid default configuration
 RUN echo Downloading phoss SMP $SMP_VERSION \
-  && wget -nv https://github.com/phax/phoss-smp/releases/download/phoss-smp-parent-pom-$SMP_VERSION/phoss-smp-webapp-xml-$SMP_VERSION.war -O smp.zip \ 
+  && wget -nv https://github.com/phax/phoss-smp/releases/download/phoss-smp-parent-pom-$SMP_VERSION/phoss-smp-webapp-xml-$SMP_VERSION.war -O smp.zip \
   && unzip smp.zip -d /smp \
   && rm /smp/WEB-INF/classes/application.properties
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -142,6 +142,8 @@ docker rm phoss-smp-release-binary-sql
 It exposes port 8888 where Tomcat is running successfully.
 Open `http://localhost:8888` in your browser.
 
+The SQL image includes JDBC drivers for PostgreSQL, MySQL, Oracle, DB2 and Microsoft SQL Server so that one artefact works with every supported database. Unused drivers stay on disk (about 20 MB in `WEB-INF/lib`) but are never loaded. A downstream image that only uses one database can delete the other driver JARs from `WEB-INF/lib`.
+
 
 ### Release Binary, MongoDB backend
 


### PR DESCRIPTION
The three `Dockerfile-release-binary-*` files download an already-built WAR in a discarded first stage. That stage currently uses `ubuntu:latest` and runs `apt-get upgrade`, so the build is not pinned, and the `wget` line has a trailing space after the continuation backslash.

This keeps the same wget/unzip behaviour on `ubuntu:24.04`, installs only `ca-certificates`, `wget` and `unzip`, and leaves the Tomcat/JRE final stage unchanged.

The SQL Docker README now also notes that the image ships every supported JDBC driver (~20 MB) so a single-database downstream image can drop the unused ones.

The final runtime image is still `tomcat:10.1-jre25`.