### PR TITLE
Fix X-Forwarded request port fallback

### DIFF
--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestDataProvider.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestDataProvider.java
@@ -136,7 +136,7 @@ public class SMPRestDataProvider implements ISMPServerAPIDataProvider
     // Try to use as many "X-Forwarded-*" header values as possible. The parts not present will
     // be replaced with
     final HttpServletRequest aHttpRequest = m_aRequestScope.getRequest ();
-    boolean bFallbackToLocalPort = false;
+    boolean bFallbackToLocalPort = true;
 
     // Scheme
     String sScheme = m_aRequestScope.headers ().getFirstHeaderValue (HTTP_X_FORWARDED_PROTO);

--- a/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/rest/SMPRestDataProviderTest.java
+++ b/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/rest/SMPRestDataProviderTest.java
@@ -50,12 +50,18 @@ public final class SMPRestDataProviderTest
 
   private IConfigWithFallback m_aOldConfig;
 
+  private static void _setPublicURLMode (@NonNull final String sMode)
+  {
+    final ICommonsMap <String, String> aConfigValues = new CommonsHashMap <> ();
+    aConfigValues.put (SMPServerConfiguration.KEY_SMP_PUBLIC_URL_MODE, sMode);
+    SMPConfigProvider.setConfig (new SMPConfig (new ConfigurationSourceFunction (aConfigValues::get)));
+  }
+
   @Before
   public void before ()
   {
-    final ICommonsMap <String, String> aConfigValues = new CommonsHashMap <> ();
-    aConfigValues.put (SMPServerConfiguration.KEY_SMP_PUBLIC_URL_MODE, "forwarded-header");
-    m_aOldConfig = SMPConfigProvider.setConfig (new SMPConfig (new ConfigurationSourceFunction (aConfigValues::get)));
+    m_aOldConfig = SMPConfigProvider.getConfig ();
+    _setPublicURLMode ("forwarded-header");
 
     ServletContextPathHolder.clearContextPath ();
     ServletContextPathHolder.setCustomContextPath (CONTEXT_PATH);
@@ -142,6 +148,18 @@ public final class SMPRestDataProviderTest
     final SMPRestDataProvider aDP = _createDataProvider (null);
     assertEquals ("http://internal.host:90" + CONTEXT_PATH + "/iso6523-actorid-upis%3A%3A9915%3Atest",
                   aDP.getCurrentURI ().toString ());
+  }
+
+  @Test
+  public void testNoXForwardedHeadersUsesRequestData ()
+  {
+    _setPublicURLMode ("x-forwarded-header");
+
+    final SMPRestDataProvider aDP = _createDataProvider (null);
+    assertEquals ("http://internal.host:90" + CONTEXT_PATH + "/iso6523-actorid-upis%3A%3A9915%3Atest",
+                  aDP.getCurrentURI ().toString ());
+    assertEquals ("http://internal.host:90" + CONTEXT_PATH,
+                  aDP.getBaseUriBuilder ());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- preserve the request port when `smp.publicurl.mode=x-forwarded-header` receives no `X-Forwarded-*` headers
- add regression coverage for both the current request URI and generated base URI
- make the test URL mode configurable so the existing data-provider tests can cover both forwarded modes

## Background

The proxy-aware mode introduced for #369 is intended to fall back to the current request data when forwarding headers are absent. However, `bFallbackToLocalPort` starts as `false` and is only ever assigned `false`, making the local-port fallback unreachable. For an internal request such as `http://internal.host:90/smp/...`, the generated URL therefore drops port `90`.

The new test reproduces that failure before the production change and passes when the fallback flag starts enabled.

## Tests

- `mvn -pl phoss-smp-webapp -am -Dtest=SMPRestDataProviderTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl phoss-smp-webapp -am test`
