### PR TITLE
Restrict relaxed SML hostname verification to local hosts

### DIFF
--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/smlhook/SmpSmlHelper.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/smlhook/SmpSmlHelper.java
@@ -78,7 +78,8 @@ public final class SmpSmlHelper
     // else local, http only access - no socket factory
 
     // Hostname verifier
-    if (sLowerURL.contains ("//localhost") || sLowerURL.contains ("//127.0.0.1"))
+    final String sHost = aSMLEndpointURL.getHost ();
+    if ("localhost".equalsIgnoreCase (sHost) || "127.0.0.1".equals (sHost))
     {
       // Accept all hostnames
       aCaller.setHostnameVerifier (new HostnameVerifierVerifyAll (false));

--- a/phoss-smp-backend/src/test/java/com/helger/phoss/smp/smlhook/SmpSmlHelperTest.java
+++ b/phoss-smp-backend/src/test/java/com/helger/phoss/smp/smlhook/SmpSmlHelperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * The Original Code is Copyright The Peppol project (http://www.peppol.eu)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.helger.phoss.smp.smlhook;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.helger.peppol.sml.SMLInfo;
+import com.helger.peppol.smlclient.ManageParticipantIdentifierServiceCaller;
+
+/**
+ * Test class for class {@link SmpSmlHelper}.
+ *
+ * @author vinit-thummar
+ */
+public final class SmpSmlHelperTest
+{
+  private static ManageParticipantIdentifierServiceCaller _createCaller (final String sManagementServiceURL)
+  {
+    return SmpSmlHelper.createSMLCallerPI (SMLInfo.builder ()
+                                                 .id ("test")
+                                                 .displayName ("Test")
+                                                 .dnsZone ("example.org")
+                                                 .managementServiceURL (sManagementServiceURL)
+                                                 .clientCertificateRequired (false)
+                                                 .build ());
+  }
+
+  @Test
+  public void testRelaxedHostnameVerifierIsRestrictedToLocalhost ()
+  {
+    assertNotNull (_createCaller ("http://localhost").getHostnameVerifier ());
+    assertNotNull (_createCaller ("http://LOCALHOST").getHostnameVerifier ());
+    assertNotNull (_createCaller ("http://127.0.0.1").getHostnameVerifier ());
+
+    assertNull (_createCaller ("http://localhost.example.org").getHostnameVerifier ());
+    assertNull (_createCaller ("http://127.0.0.1.example.org").getHostnameVerifier ());
+    assertNull (_createCaller ("http://localhost@example.org").getHostnameVerifier ());
+    assertNull (_createCaller ("http://example.org//localhost").getHostnameVerifier ());
+  }
+}


### PR DESCRIPTION
## Summary
- determine local SML endpoints from the parsed URL host
- apply the relaxed hostname verifier only to exact localhost or 127.0.0.1 hosts
- add regression coverage for hostname prefixes, user-info, and path substrings

## Problem
The current full-URL substring check also matches non-local endpoints such as localhost.example.org, URLs containing localhost as user-info, and paths containing //localhost. Those endpoints therefore receive HostnameVerifierVerifyAll even though their actual host is not local.

Using URL.getHost() preserves the intended local-development behavior without relaxing hostname verification for unrelated hosts.

## Testing
- mvn -pl phoss-smp-backend -am -Dtest=SmpSmlHelperTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean verify
- all nine reactor modules succeeded