### PR TITLE
Fix MongoDB transport profile delete audit type

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDB.java
@@ -30,7 +30,6 @@ import com.helger.collection.commons.ICommonsList;
 import com.helger.peppol.smp.ESMPTransportProfileState;
 import com.helger.peppol.smp.ISMPTransportProfile;
 import com.helger.peppol.smp.SMPTransportProfile;
-import com.helger.phoss.smp.domain.redirect.SMPRedirect;
 import com.helger.phoss.smp.domain.transportprofile.ISMPTransportProfileManager;
 import com.helger.photon.audit.AuditHelper;
 import com.mongodb.client.model.Indexes;
@@ -133,10 +132,10 @@ public final class SMPTransportProfileManagerMongoDB extends AbstractManagerMong
     final DeleteResult aDR = getCollection ().deleteOne (new Document (BSON_ID, sSMPTransportProfileID));
     if (!aDR.wasAcknowledged () || aDR.getDeletedCount () == 0)
     {
-      AuditHelper.onAuditDeleteFailure (SMPRedirect.OT, sSMPTransportProfileID, "no-such-id");
+      AuditHelper.onAuditDeleteFailure (SMPTransportProfile.OT, sSMPTransportProfileID, "no-such-id");
       return EChange.UNCHANGED;
     }
-    AuditHelper.onAuditDeleteSuccess (SMPRedirect.OT, sSMPTransportProfileID);
+    AuditHelper.onAuditDeleteSuccess (SMPTransportProfile.OT, sSMPTransportProfileID);
     return EChange.CHANGED;
   }
 

--- a/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDBTest.java
+++ b/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDBTest.java
@@ -20,17 +20,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+import com.helger.base.type.ObjectType;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.peppol.smp.ESMPTransportProfile;
 import com.helger.peppol.smp.ESMPTransportProfileState;
 import com.helger.peppol.smp.ISMPTransportProfile;
+import com.helger.peppol.smp.SMPTransportProfile;
 import com.helger.phoss.smp.backend.mongodb.SMPServerMongoDBTestRule;
 import com.helger.phoss.smp.domain.SMPMetaManager;
 import com.helger.phoss.smp.domain.transportprofile.ISMPTransportProfileManager;
+import com.helger.photon.audit.AuditHelper;
+import com.helger.photon.audit.IAuditor;
 
 /**
  * Test class for class {@link SMPTransportProfileManagerMongoDB}.
@@ -75,5 +81,33 @@ public final class SMPTransportProfileManagerMongoDBTest
     for (final ISMPTransportProfile aCreate : aCreated)
       assertTrue (aMgr.deleteSMPTransportProfile (aCreate.getID ()).isChanged ());
     assertEquals (0, aMgr.getAllSMPTransportProfiles ().size ());
+  }
+
+  @Test
+  public void testDeleteAuditObjectType ()
+  {
+    final ISMPTransportProfileManager aMgr = SMPMetaManager.getTransportProfileMgr ();
+    final String sID = "test-audit-profile";
+    assertNotNull (aMgr.createSMPTransportProfile (sID, "Test audit profile", false));
+
+    final IAuditor aOldAuditor = AuditHelper.getAuditor ();
+    final AtomicReference <ObjectType> aAuditObjectType = new AtomicReference <> ();
+    try
+    {
+      AuditHelper.setAuditor ( (eActionType, eSuccess, aActionObjectType, sAction, aArgs) -> {
+        aAuditObjectType.set (aActionObjectType);
+      });
+
+      assertTrue (aMgr.deleteSMPTransportProfile (sID).isChanged ());
+      assertEquals (SMPTransportProfile.OT, aAuditObjectType.get ());
+
+      aAuditObjectType.set (null);
+      assertTrue (aMgr.deleteSMPTransportProfile (sID).isUnchanged ());
+      assertEquals (SMPTransportProfile.OT, aAuditObjectType.get ());
+    }
+    finally
+    {
+      AuditHelper.setAuditor (aOldAuditor);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- use the transport-profile object type for MongoDB deletion audit entries
- cover both successful and failed deletion audit paths with a regression test

## Problem
The MongoDB transport-profile manager currently records deletion events with the redirect object type. This makes transport-profile deletions appear as redirect deletions in audit history and differs from the SQL and XML backends.

## Testing
- mvn -pl phoss-smp-backend-mongodb -am -Dtest=SMPTransportProfileManagerMongoDBTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean verify
- all nine reactor modules succeeded