### PR TITLE
Fix MongoDB manager field mappings

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceGroupManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceGroupManagerMongoDB.java
@@ -323,7 +323,7 @@ public final class SMPServiceGroupManagerMongoDB extends AbstractManagerMongoDB 
   public ICommonsSet <String> getAllSMPServiceGroupIDs ()
   {
     final ICommonsSet <String> ret = new CommonsHashSet <> ();
-    getCollection ().find ().forEach (x -> ret.add (x.getString (BSON_OWNER_ID)));
+    getCollection ().find ().forEach (x -> ret.add (x.getString (BSON_ID)));
     return ret;
   }
 

--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDB.java
@@ -110,8 +110,9 @@ public final class SMPTransportProfileManagerMongoDB extends AbstractManagerMong
   {
     final Document aOldDoc = getCollection ().findOneAndUpdate (new Document (BSON_ID, sSMPTransportProfileID),
                                                                 Updates.combine (Updates.set (BSON_NAME, sName),
-                                                                                 Updates.set (BSON_DEPRECATED,
-                                                                                              Boolean.valueOf (bIsDeprecated))));
+                                                                                 Updates.set (BSON_STATE,
+                                                                                              (bIsDeprecated ? ESMPTransportProfileState.DEPRECATED
+                                                                                                             : ESMPTransportProfileState.ACTIVE).getID ())));
     if (aOldDoc == null)
       return EChange.UNCHANGED;
 

--- a/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceGroupManagerMongoDBTest.java
+++ b/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceGroupManagerMongoDBTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.backend.mongodb.mgr;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.helger.peppolid.IParticipantIdentifier;
+import com.helger.peppolid.factory.IIdentifierFactory;
+import com.helger.peppolid.peppol.PeppolIdentifierHelper;
+import com.helger.phoss.smp.backend.mongodb.SMPServerMongoDBTestRule;
+import com.helger.phoss.smp.domain.SMPMetaManager;
+import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroup;
+import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroupManager;
+import com.helger.phoss.smp.exception.SMPServerException;
+
+/**
+ * Test class for class {@link SMPServiceGroupManagerMongoDB}.
+ *
+ * @author vinit-thummar
+ */
+public final class SMPServiceGroupManagerMongoDBTest
+{
+  @Rule
+  public final TestRule m_aRule = new SMPServerMongoDBTestRule ();
+
+  @Test
+  public void testGetAllServiceGroupIDs () throws SMPServerException
+  {
+    final IIdentifierFactory aIdentifierFactory = SMPMetaManager.getIdentifierFactory ();
+    final IParticipantIdentifier aParticipantID = aIdentifierFactory.createParticipantIdentifier (PeppolIdentifierHelper.DEFAULT_PARTICIPANT_SCHEME,
+                                                                                                   "0088:mongodb-service-group-ids");
+    assertNotNull (aParticipantID);
+
+    final ISMPServiceGroupManager aMgr = SMPMetaManager.getServiceGroupMgr ();
+    final String sOwnerID = "mongodb-service-group-owner";
+    aMgr.deleteSMPServiceGroupNoEx (aParticipantID, false);
+    final ISMPServiceGroup aServiceGroup = aMgr.createSMPServiceGroup (sOwnerID,
+                                                                      aParticipantID,
+                                                                      null,
+                                                                      null,
+                                                                      false);
+    try
+    {
+      assertTrue (aMgr.getAllSMPServiceGroupIDs ().contains (aServiceGroup.getID ()));
+      assertFalse (aMgr.getAllSMPServiceGroupIDs ().contains (sOwnerID));
+    }
+    finally
+    {
+      aMgr.deleteSMPServiceGroupNoEx (aParticipantID, false);
+    }
+  }
+}

--- a/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDBTest.java
+++ b/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPTransportProfileManagerMongoDBTest.java
@@ -84,6 +84,26 @@ public final class SMPTransportProfileManagerMongoDBTest
   }
 
   @Test
+  public void testUpdateState ()
+  {
+    final ISMPTransportProfileManager aMgr = SMPMetaManager.getTransportProfileMgr ();
+    final String sID = "test-update-state";
+    assertNotNull (aMgr.createSMPTransportProfile (sID, "Test update state", false));
+    try
+    {
+      assertTrue (aMgr.updateSMPTransportProfile (sID, "Test update state", true).isChanged ());
+      assertEquals (ESMPTransportProfileState.DEPRECATED, aMgr.getSMPTransportProfileOfID (sID).getState ());
+
+      assertTrue (aMgr.updateSMPTransportProfile (sID, "Test update state", false).isChanged ());
+      assertEquals (ESMPTransportProfileState.ACTIVE, aMgr.getSMPTransportProfileOfID (sID).getState ());
+    }
+    finally
+    {
+      aMgr.deleteSMPTransportProfile (sID);
+    }
+  }
+
+  @Test
   public void testDeleteAuditObjectType ()
   {
     final ISMPTransportProfileManager aMgr = SMPMetaManager.getTransportProfileMgr ();


### PR DESCRIPTION
## Summary

- write transport profile updates to the current `state` field instead of the legacy `deprecated` field
- return service group IDs from the stored `id` field instead of returning owner IDs
- add MongoDB regression coverage for both state transitions and service group ID listing

## Why

Transport profiles are serialized and read through `state`, so updating only `deprecated` reports success without changing the state returned by MongoDB. Likewise, `getAllSMPServiceGroupIDs()` currently reads `ownerid`, causing callers such as the service group ID API, endpoint tree, and import checks to receive owner IDs instead of participant/service group IDs.

## Verification

- focused MongoDB manager tests: 4 tests, 0 failures
- `mvn clean verify`: all 9 reactor modules passed (backend, SQL, XML, MongoDB, and all webapps)