### PR TITLE
Added server side pagination

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPBusinessCardManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPBusinessCardManagerMongoDB.java
@@ -41,6 +41,7 @@ import com.helger.collection.commons.ICommonsList;
 import com.helger.collection.commons.ICommonsSet;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.factory.IIdentifierFactory;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 import com.helger.phoss.smp.domain.businesscard.ISMPBusinessCard;
 import com.helger.phoss.smp.domain.businesscard.ISMPBusinessCardCallback;
 import com.helger.phoss.smp.domain.businesscard.ISMPBusinessCardManager;
@@ -52,6 +53,7 @@ import com.helger.phoss.smp.domain.businesscard.SMPBusinessCardName;
 import com.helger.photon.audit.AuditHelper;
 import com.helger.typeconvert.impl.TypeConverter;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
 import com.mongodb.client.result.DeleteResult;
 
 /**
@@ -360,6 +362,24 @@ public final class SMPBusinessCardManagerMongoDB extends AbstractManagerMongoDB 
   {
     final ICommonsList <ISMPBusinessCard> ret = new CommonsArrayList <> ();
     getCollection ().find ().forEach (x -> ret.add (toDomain (x)));
+    return ret;
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPBusinessCard> getAllSMPBusinessCards (@Nonnegative final int nStartIndex,
+                                                                 @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+
+    final ICommonsList <ISMPBusinessCard> ret = new CommonsArrayList <> ();
+    if (nMaxCount > 0)
+      getCollection ().find ()
+                      .sort (Sorts.ascending (BSON_SERVICE_GROUP_ID))
+                      .skip (nStartIndex)
+                      .limit (nMaxCount)
+                      .forEach (x -> ret.add (toDomain (x)));
     return ret;
   }
 

--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPRedirectManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPRedirectManagerMongoDB.java
@@ -39,6 +39,7 @@ import com.helger.collection.commons.ICommonsList;
 import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.factory.IIdentifierFactory;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirect;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirectCallback;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirectManager;
@@ -48,6 +49,7 @@ import com.helger.security.certificate.CertificateDecodeHelper;
 import com.helger.security.certificate.CertificateHelper;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
 import com.mongodb.client.result.DeleteResult;
 
 /**
@@ -269,6 +271,24 @@ public final class SMPRedirectManagerMongoDB extends AbstractManagerMongoDB impl
   {
     final ICommonsList <ISMPRedirect> ret = new CommonsArrayList <> ();
     getCollection ().find ().forEach (x -> ret.add (toDomain (x)));
+    return ret;
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPRedirect> getAllSMPRedirects (@Nonnegative final int nStartIndex,
+                                                         @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+
+    final ICommonsList <ISMPRedirect> ret = new CommonsArrayList <> ();
+    if (nMaxCount > 0)
+      getCollection ().find ()
+                      .sort (Sorts.ascending (BSON_SERVICE_GROUP_ID, BSON_DOCTYPE_ID))
+                      .skip (nStartIndex)
+                      .limit (nMaxCount)
+                      .forEach (x -> ret.add (toDomain (x)));
     return ret;
   }
 

--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceGroupManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceGroupManagerMongoDB.java
@@ -37,6 +37,7 @@ import com.helger.collection.commons.ICommonsSet;
 import com.helger.json.IJsonArray;
 import com.helger.json.serialize.JsonReader;
 import com.helger.peppolid.IParticipantIdentifier;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 import com.helger.phoss.smp.domain.SMPMetaManager;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirectManager;
 import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroup;
@@ -53,6 +54,7 @@ import com.helger.phoss.smp.smlhook.RegistrationHookException;
 import com.helger.phoss.smp.smlhook.RegistrationHookFactory;
 import com.helger.photon.audit.AuditHelper;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.DeleteResult;
 
@@ -315,6 +317,24 @@ public final class SMPServiceGroupManagerMongoDB extends AbstractManagerMongoDB 
   {
     final ICommonsList <ISMPServiceGroup> ret = new CommonsArrayList <> ();
     getCollection ().find ().forEach (x -> ret.add (toDomain (x)));
+    return ret;
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPServiceGroup> getAllSMPServiceGroups (@Nonnegative final int nStartIndex,
+                                                                 @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+
+    final ICommonsList <ISMPServiceGroup> ret = new CommonsArrayList <> ();
+    if (nMaxCount > 0)
+      getCollection ().find ()
+                      .sort (Sorts.ascending (BSON_ID))
+                      .skip (nStartIndex)
+                      .limit (nMaxCount)
+                      .forEach (x -> ret.add (toDomain (x)));
     return ret;
   }
 

--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDB.java
@@ -47,6 +47,7 @@ import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.IProcessIdentifier;
 import com.helger.peppolid.factory.IIdentifierFactory;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 import com.helger.phoss.smp.domain.serviceinfo.EndpointUsageInfo;
 import com.helger.phoss.smp.domain.serviceinfo.IEndpointUsageInfo;
 import com.helger.phoss.smp.domain.serviceinfo.ISMPEndpoint;
@@ -62,6 +63,7 @@ import com.helger.phoss.smp.security.SMPCertificateHelper;
 import com.helger.photon.audit.AuditHelper;
 import com.helger.typeconvert.impl.TypeConverter;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
 import com.mongodb.client.result.DeleteResult;
 
 /**
@@ -457,6 +459,24 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
   {
     final ICommonsList <ISMPServiceInformation> ret = new CommonsArrayList <> ();
     forEachSMPServiceInformation (ret::add);
+    return ret;
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPServiceInformation> getAllSMPServiceInformation (@Nonnegative final int nStartIndex,
+                                                                            @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+
+    final ICommonsList <ISMPServiceInformation> ret = new CommonsArrayList <> ();
+    if (nMaxCount > 0)
+      getCollection ().find ()
+                      .sort (Sorts.ascending (BSON_SERVICE_GROUP_ID, BSON_DOCTYPE_ID))
+                      .skip (nStartIndex)
+                      .limit (nMaxCount)
+                      .forEach (x -> ret.add (toServiceInformation (x, true)));
     return ret;
   }
 

--- a/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/SMPJDBCPagingHelper.java
+++ b/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/SMPJDBCPagingHelper.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2019-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * The Original Code is Copyright The Peppol project (http://www.peppol.eu)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.helger.phoss.smp.backend.sql;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.annotation.concurrent.Immutable;
+import com.helger.db.api.EDatabaseSystemType;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
+
+/**
+ * Helper class to create the database specific SQL clause to limit a query to a single "page" of
+ * results. Requires an <code>ORDER BY</code> clause to be present in the query, to ensure a stable
+ * order.
+ *
+ * @author Philip Helger
+ * @since 8.2.1
+ */
+@Immutable
+public final class SMPJDBCPagingHelper
+{
+  private SMPJDBCPagingHelper ()
+  {}
+
+  /**
+   * Get the database specific SQL clause to only return a single "page" of a query result. The
+   * returned clause starts with a blank and must be appended to a query that contains an
+   * <code>ORDER BY</code> clause.
+   *
+   * @param eDBType
+   *        The database type to use. May not be <code>null</code>.
+   * @param nStartIndex
+   *        The 0-based index of the first row to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of rows to be returned. Must be &ge; 0.
+   * @return The SQL clause to be appended. Never <code>null</code>.
+   */
+  @NonNull
+  public static String getPagingClause (@NonNull final EDatabaseSystemType eDBType,
+                                        @Nonnegative final int nStartIndex,
+                                        @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+
+    // MySQL does not support the SQL standard "OFFSET .. FETCH" syntax
+    if (eDBType == EDatabaseSystemType.MYSQL)
+      return " LIMIT " + nMaxCount + " OFFSET " + nStartIndex;
+
+    // DB2, Oracle, PostgreSQL and SQL Server all support the SQL standard
+    return " OFFSET " + nStartIndex + " ROWS FETCH NEXT " + nMaxCount + " ROWS ONLY";
+  }
+
+  /**
+   * Get the database specific SQL clause to only return a single "page" of a query result, using
+   * the currently configured database type.
+   *
+   * @param nStartIndex
+   *        The 0-based index of the first row to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of rows to be returned. Must be &ge; 0.
+   * @return The SQL clause to be appended. Never <code>null</code>.
+   */
+  @NonNull
+  public static String getPagingClause (@Nonnegative final int nStartIndex, @Nonnegative final int nMaxCount)
+  {
+    return getPagingClause (SMPDataSourceSingleton.getDatabaseType (), nStartIndex, nMaxCount);
+  }
+}

--- a/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPBusinessCardManagerJDBC.java
+++ b/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPBusinessCardManagerJDBC.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phoss.smp.backend.sql.mgr;
 
+import java.util.Comparator;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,8 @@ import com.helger.json.serialize.JsonReader;
 import com.helger.json.serialize.JsonWriterSettings;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.factory.IIdentifierFactory;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
+import com.helger.phoss.smp.backend.sql.SMPJDBCPagingHelper;
 import com.helger.phoss.smp.domain.SMPMetaManager;
 import com.helger.phoss.smp.domain.businesscard.ISMPBusinessCard;
 import com.helger.phoss.smp.domain.businesscard.ISMPBusinessCardCallback;
@@ -357,10 +360,42 @@ public final class SMPBusinessCardManagerJDBC extends AbstractJDBCEnabledManager
   @ReturnsMutableCopy
   public ICommonsList <ISMPBusinessCard> getAllSMPBusinessCards ()
   {
+    return _convertToBusinessCards (newExecutor ().queryAll ("SELECT id, pid, name, names, country, geoinfo, identifiers, websites, contacts, addon, regdate" +
+                                                             " FROM " +
+                                                             m_sTableName));
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPBusinessCard> getAllSMPBusinessCards (@Nonnegative final int nStartIndex,
+                                                                 @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+    if (nMaxCount == 0)
+      return new CommonsArrayList <> ();
+
+    // A Business Card consists of 1-n rows in the DB (one per Business Entity),
+    // so the paging must happen on the distinct participant IDs
+    final String sSQL = "SELECT bce.id, bce.pid, bce.name, bce.names, bce.country, bce.geoinfo, bce.identifiers, bce.websites, bce.contacts, bce.addon, bce.regdate" +
+                        " FROM " +
+                        m_sTableName +
+                        " bce INNER JOIN (SELECT DISTINCT pid FROM " +
+                        m_sTableName +
+                        " ORDER BY pid" +
+                        SMPJDBCPagingHelper.getPagingClause (nStartIndex, nMaxCount) +
+                        ") paged ON bce.pid=paged.pid";
+    final ICommonsList <ISMPBusinessCard> ret = _convertToBusinessCards (newExecutor ().queryAll (sSQL));
+    // The DB result is grouped in a Map, so the order needs to be restored
+    ret.sort (Comparator.comparing (ISMPBusinessCard::getID));
+    return ret;
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  private static ICommonsList <ISMPBusinessCard> _convertToBusinessCards (@Nullable final ICommonsList <DBResultRow> aDBResult)
+  {
     final ICommonsList <ISMPBusinessCard> ret = new CommonsArrayList <> ();
-    final ICommonsList <DBResultRow> aDBResult = newExecutor ().queryAll ("SELECT id, pid, name, names, country, geoinfo, identifiers, websites, contacts, addon, regdate" +
-                                                                          " FROM " +
-                                                                          m_sTableName);
     if (aDBResult != null)
     {
       final IIdentifierFactory aIF = SMPMetaManager.getIdentifierFactory ();

--- a/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPRedirectManagerJDBC.java
+++ b/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPRedirectManagerJDBC.java
@@ -44,6 +44,8 @@ import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.simple.doctype.SimpleDocumentTypeIdentifier;
 import com.helger.peppolid.simple.participant.SimpleParticipantIdentifier;
+import com.helger.phoss.smp.backend.sql.SMPJDBCPagingHelper;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirect;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirectCallback;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirectManager;
@@ -268,9 +270,31 @@ public final class SMPRedirectManagerJDBC extends AbstractJDBCEnabledManager imp
   @ReturnsMutableCopy
   public ICommonsList <ISMPRedirect> getAllSMPRedirects ()
   {
+    return _getAllSMPRedirects (null);
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPRedirect> getAllSMPRedirects (@Nonnegative final int nStartIndex,
+                                                         @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+    if (nMaxCount == 0)
+      return new CommonsArrayList <> ();
+
+    return _getAllSMPRedirects (" ORDER BY businessIdentifierScheme, businessIdentifier, documentIdentifierScheme, documentIdentifier" +
+                                SMPJDBCPagingHelper.getPagingClause (nStartIndex, nMaxCount));
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  private ICommonsList <ISMPRedirect> _getAllSMPRedirects (@Nullable final String sSuffix)
+  {
     final ICommonsList <DBResultRow> aDBResult = newExecutor ().queryAll ("SELECT businessIdentifierScheme, businessIdentifier, documentIdentifierScheme, documentIdentifier, redirectionUrl, certificateUID, certificate, extension" +
                                                                           " FROM " +
-                                                                          m_sTableName);
+                                                                          m_sTableName +
+                                                                          (sSuffix == null ? "" : sSuffix));
     final ICommonsList <ISMPRedirect> ret = new CommonsArrayList <> ();
     if (aDBResult != null)
       for (final DBResultRow aRow : aDBResult)

--- a/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPServiceGroupManagerJDBC.java
+++ b/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPServiceGroupManagerJDBC.java
@@ -51,6 +51,8 @@ import com.helger.json.serialize.JsonReader;
 import com.helger.peppolid.CIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.simple.participant.SimpleParticipantIdentifier;
+import com.helger.phoss.smp.backend.sql.SMPJDBCPagingHelper;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroup;
 import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroupCallback;
 import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroupManager;
@@ -458,13 +460,38 @@ public final class SMPServiceGroupManagerJDBC extends AbstractJDBCEnabledManager
     if (LOGGER.isDebugEnabled ())
       LOGGER.debug ("getAllSMPServiceGroups()");
 
+    return _getAllSMPServiceGroups (null);
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPServiceGroup> getAllSMPServiceGroups (@Nonnegative final int nStartIndex,
+                                                                 @Nonnegative final int nMaxCount)
+  {
+    if (LOGGER.isDebugEnabled ())
+      LOGGER.debug ("getAllSMPServiceGroups(" + nStartIndex + ", " + nMaxCount + ")");
+
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+    if (nMaxCount == 0)
+      return new CommonsArrayList <> ();
+
+    return _getAllSMPServiceGroups (" ORDER BY sg.businessIdentifierScheme, sg.businessIdentifier" +
+                                    SMPJDBCPagingHelper.getPagingClause (nStartIndex, nMaxCount));
+  }
+
+  @NonNull
+  @ReturnsMutableCopy
+  private ICommonsList <ISMPServiceGroup> _getAllSMPServiceGroups (@Nullable final String sSuffix)
+  {
     final ICommonsList <DBResultRow> aDBResult = newExecutor ().queryAll ("SELECT sg.businessIdentifierScheme, sg.businessIdentifier, sg.extension, so.username, sg.customproperties" +
                                                                           " FROM " +
                                                                           m_sTableNameSG +
                                                                           " sg, " +
                                                                           m_sTableNameO +
                                                                           " so" +
-                                                                          " WHERE so.businessIdentifierScheme=sg.businessIdentifierScheme AND so.businessIdentifier=sg.businessIdentifier");
+                                                                          " WHERE so.businessIdentifierScheme=sg.businessIdentifierScheme AND so.businessIdentifier=sg.businessIdentifier" +
+                                                                          (sSuffix == null ? "" : sSuffix));
 
     final ICommonsList <ISMPServiceGroup> ret = new CommonsArrayList <> ();
     if (aDBResult != null)

--- a/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPServiceInformationManagerJDBC.java
+++ b/phoss-smp-backend-sql/src/main/java/com/helger/phoss/smp/backend/sql/mgr/SMPServiceInformationManagerJDBC.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phoss.smp.backend.sql.mgr;
 
+import java.util.Comparator;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -52,6 +53,8 @@ import com.helger.peppolid.IProcessIdentifier;
 import com.helger.peppolid.simple.doctype.SimpleDocumentTypeIdentifier;
 import com.helger.peppolid.simple.participant.SimpleParticipantIdentifier;
 import com.helger.peppolid.simple.process.SimpleProcessIdentifier;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
+import com.helger.phoss.smp.backend.sql.SMPJDBCPagingHelper;
 import com.helger.phoss.smp.domain.serviceinfo.EndpointUsageInfo;
 import com.helger.phoss.smp.domain.serviceinfo.IEndpointUsageInfo;
 import com.helger.phoss.smp.domain.serviceinfo.ISMPEndpoint;
@@ -408,15 +411,49 @@ public final class SMPServiceInformationManagerJDBC extends AbstractJDBCEnabledM
     return ret;
   }
 
+  @NonNull
+  @ReturnsMutableCopy
+  @Override
+  public ICommonsList <ISMPServiceInformation> getAllSMPServiceInformation (@Nonnegative final int nStartIndex,
+                                                                            @Nonnegative final int nMaxCount)
+  {
+    SMPPagingHelper.checkPagingParams (nStartIndex, nMaxCount);
+
+    final ICommonsList <ISMPServiceInformation> ret = new CommonsArrayList <> ();
+    if (nMaxCount > 0)
+      _forEachSMPServiceInformation (" ORDER BY sm.businessIdentifierScheme, sm.businessIdentifier, sm.documentIdentifierScheme, sm.documentIdentifier" +
+                                     SMPJDBCPagingHelper.getPagingClause (nStartIndex, nMaxCount),
+                                     ret::add);
+    // The DB result is grouped in a Map, so the order needs to be restored
+    ret.sort (Comparator.comparing (ISMPServiceInformation::getServiceGroupID)
+                        .thenComparing (x -> x.getDocumentTypeIdentifier ().getURIEncoded ()));
+    return ret;
+  }
+
   public void forEachSMPServiceInformation (@NonNull final Consumer <? super ISMPServiceInformation> aConsumer)
   {
+    _forEachSMPServiceInformation (null, aConsumer);
+  }
+
+  private void _forEachSMPServiceInformation (@Nullable final String sServiceMetadataSuffix,
+                                              @NonNull final Consumer <? super ISMPServiceInformation> aConsumer)
+  {
+    // If only a single page shall be returned, the paging must happen on the
+    // Service Metadata level, because the joins create multiple rows per
+    // Service Information object
+    final String sServiceMetadataTable = sServiceMetadataSuffix == null ? m_sTableNameSM
+                                                                       : "(SELECT businessIdentifierScheme, businessIdentifier, documentIdentifierScheme, documentIdentifier, extension FROM " +
+                                                                         m_sTableNameSM +
+                                                                         " sm" +
+                                                                         sServiceMetadataSuffix +
+                                                                         ")";
     final ICommonsList <DBResultRow> aDBResult = newExecutor ().queryAll ("SELECT sm.businessIdentifierScheme, sm.businessIdentifier, sm.documentIdentifierScheme, sm.documentIdentifier, sm.extension," +
                                                                           "   sp.processIdentifierType, sp.processIdentifier, sp.extension," +
                                                                           "   se.id, se.transportProfile, se.endpointReference, se.requireBusinessLevelSignature, se.minimumAuthenticationLevel," +
                                                                           "     se.serviceActivationDate, se.serviceExpirationDate, se.certificate, se.serviceDescription," +
                                                                           "     se.technicalContactUrl, se.technicalInformationUrl, se.extension" +
                                                                           " FROM " +
-                                                                          m_sTableNameSM +
+                                                                          sServiceMetadataTable +
                                                                           " sm" +
                                                                           " INNER JOIN " +
                                                                           m_sTableNameP +

--- a/phoss-smp-backend-sql/src/test/java/com/helger/phoss/smp/backend/sql/SMPJDBCPagingHelperTest.java
+++ b/phoss-smp-backend-sql/src/test/java/com/helger/phoss/smp/backend/sql/SMPJDBCPagingHelperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * The Original Code is Copyright The Peppol project (http://www.peppol.eu)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.helger.phoss.smp.backend.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.helger.db.api.EDatabaseSystemType;
+
+/**
+ * Test class for class {@link SMPJDBCPagingHelper}.
+ *
+ * @author Philip Helger
+ */
+public final class SMPJDBCPagingHelperTest
+{
+  @Test
+  public void testGetPagingClause ()
+  {
+    // MySQL uses a proprietary syntax
+    assertEquals (" LIMIT 25 OFFSET 50", SMPJDBCPagingHelper.getPagingClause (EDatabaseSystemType.MYSQL, 50, 25));
+
+    // All other supported DBs use the SQL standard syntax
+    for (final EDatabaseSystemType eDBType : new EDatabaseSystemType [] { EDatabaseSystemType.DB2,
+                                                                          EDatabaseSystemType.ORACLE,
+                                                                          EDatabaseSystemType.POSTGRESQL,
+                                                                          EDatabaseSystemType.SQLSERVER })
+      assertEquals (" OFFSET 50 ROWS FETCH NEXT 25 ROWS ONLY",
+                    SMPJDBCPagingHelper.getPagingClause (eDBType, 50, 25));
+  }
+
+  @Test
+  public void testInvalidParams ()
+  {
+    try
+    {
+      SMPJDBCPagingHelper.getPagingClause (EDatabaseSystemType.MYSQL, -1, 25);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {
+      // expected
+    }
+
+    try
+    {
+      SMPJDBCPagingHelper.getPagingClause (EDatabaseSystemType.MYSQL, 0, -1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {
+      // expected
+    }
+  }
+}

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/SMPPagingHelper.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/SMPPagingHelper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * The Original Code is Copyright The Peppol project (http://www.peppol.eu)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.helger.phoss.smp.domain;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.annotation.concurrent.Immutable;
+import com.helger.annotation.style.ReturnsMutableCopy;
+import com.helger.collection.commons.CommonsArrayList;
+import com.helger.collection.commons.ICommonsList;
+
+/**
+ * Helper class for the server side pagination of manager queries. It contains the fallback
+ * implementation that is used, if a backend does not support native paging.
+ *
+ * @author Philip Helger
+ * @since 8.2.1
+ */
+@Immutable
+public final class SMPPagingHelper
+{
+  private SMPPagingHelper ()
+  {}
+
+  /**
+   * Extract a single page out of the provided list. The list is sorted with the provided comparator
+   * first, to ensure a stable order across single page requests.
+   *
+   * @param <T>
+   *        The list element type
+   * @param aList
+   *        The list to take the page from. May not be <code>null</code>. The list is sorted in
+   *        place.
+   * @param aComparator
+   *        The comparator to be used for sorting. May not be <code>null</code>.
+   * @param nStartIndex
+   *        The 0-based index of the first element to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of elements to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list.
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  public static <T> ICommonsList <T> getPage (@NonNull final ICommonsList <T> aList,
+                                              @NonNull final Comparator <? super T> aComparator,
+                                              @Nonnegative final int nStartIndex,
+                                              @Nonnegative final int nMaxCount)
+  {
+    checkPagingParams (nStartIndex, nMaxCount);
+
+    if (nMaxCount == 0 || nStartIndex >= aList.size ())
+      return new CommonsArrayList <> ();
+
+    aList.sort (aComparator);
+
+    final int nEndIndex = (int) Math.min ((long) nStartIndex + nMaxCount, aList.size ());
+    final List <T> aSubList = aList.subList (nStartIndex, nEndIndex);
+    return new CommonsArrayList <> (aSubList);
+  }
+
+  /**
+   * Check if the provided paging parameters are valid.
+   *
+   * @param nStartIndex
+   *        The 0-based index of the first element to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of elements to be returned. Must be &ge; 0.
+   * @throws IllegalArgumentException
+   *         If one of the parameters is &lt; 0.
+   */
+  public static void checkPagingParams (@Nonnegative final int nStartIndex, @Nonnegative final int nMaxCount)
+  {
+    if (nStartIndex < 0)
+      throw new IllegalArgumentException ("The start index must be >= 0 but is " + nStartIndex);
+    if (nMaxCount < 0)
+      throw new IllegalArgumentException ("The maximum count must be >= 0 but is " + nMaxCount);
+  }
+}

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/SMPPagingHelper.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/SMPPagingHelper.java
@@ -12,12 +12,15 @@ package com.helger.phoss.smp.domain;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import com.helger.annotation.Nonnegative;
 import com.helger.annotation.concurrent.Immutable;
 import com.helger.annotation.style.ReturnsMutableCopy;
+import com.helger.base.string.StringHelper;
 import com.helger.collection.commons.CommonsArrayList;
 import com.helger.collection.commons.ICommonsList;
 
@@ -68,6 +71,25 @@ public final class SMPPagingHelper
     final int nEndIndex = (int) Math.min ((long) nStartIndex + nMaxCount, aList.size ());
     final List <T> aSubList = aList.subList (nStartIndex, nEndIndex);
     return new CommonsArrayList <> (aSubList);
+  }
+
+  /**
+   * Check if the provided value contains the provided search text, ignoring case.
+   *
+   * @param sValue
+   *        The value to be checked. May be <code>null</code>.
+   * @param sSearchText
+   *        The search text to be searched. May be <code>null</code> in which case
+   *        <code>true</code> is returned.
+   * @return <code>true</code> if the search text is empty or if the value contains the search text.
+   */
+  public static boolean matchesSearchText (@Nullable final String sValue, @Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return true;
+    if (StringHelper.isEmpty (sValue))
+      return false;
+    return sValue.toLowerCase (Locale.ROOT).contains (sSearchText.toLowerCase (Locale.ROOT));
   }
 
   /**

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/businesscard/ISMPBusinessCardManager.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/businesscard/ISMPBusinessCardManager.java
@@ -21,6 +21,7 @@ import com.helger.annotation.style.ReturnsMutableCopy;
 import com.helger.annotation.style.ReturnsMutableObject;
 import com.helger.base.callback.CallbackList;
 import com.helger.base.state.EChange;
+import com.helger.base.string.StringHelper;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.collection.commons.ICommonsSet;
 import com.helger.peppolid.IParticipantIdentifier;
@@ -106,6 +107,65 @@ public interface ISMPBusinessCardManager
   }
 
   /**
+   * Get a single "page" of all SMP business cards matching the provided search text, sorted by the
+   * business card ID. This method is meant to be used for server side pagination in combination
+   * with {@link #getSMPBusinessCardCount(String)}.
+   *
+   * @param sSearchText
+   *        The search text to filter the business cards. May be <code>null</code> or empty in which
+   *        case no filtering takes place.
+   * @param nStartIndex
+   *        The 0-based index of the first matching business card to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of business cards to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of business cards.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPBusinessCard> getAllSMPBusinessCards (@Nullable final String sSearchText,
+                                                                  @Nonnegative final int nStartIndex,
+                                                                  @Nonnegative final int nMaxCount)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getAllSMPBusinessCards (nStartIndex, nMaxCount);
+
+    return SMPPagingHelper.getPage (getAllSMPBusinessCards ().getAll (x -> isMatchingSearchText (x, sSearchText)),
+                                    Comparator.comparing (ISMPBusinessCard::getID),
+                                    nStartIndex,
+                                    nMaxCount);
+  }
+
+  /**
+   * Check if the provided business card matches the provided search text. The participant ID as
+   * well as the names and the country codes of all contained entities are checked.
+   *
+   * @param aBusinessCard
+   *        The business card to check. May not be <code>null</code>.
+   * @param sSearchText
+   *        The search text to be searched. May be <code>null</code> or empty in which case
+   *        <code>true</code> is returned.
+   * @return <code>true</code> if the business card matches, <code>false</code> if not.
+   * @since 8.2.1
+   */
+  static boolean isMatchingSearchText (@NonNull final ISMPBusinessCard aBusinessCard,
+                                       @Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return true;
+
+    if (SMPPagingHelper.matchesSearchText (aBusinessCard.getID (), sSearchText))
+      return true;
+
+    return aBusinessCard.getAllEntities ()
+                        .containsAny (aEntity -> SMPPagingHelper.matchesSearchText (aEntity.getCountryCode (),
+                                                                                    sSearchText) ||
+                                                 aEntity.names ()
+                                                        .containsAny (aName -> SMPPagingHelper.matchesSearchText (aName.getName (),
+                                                                                                                  sSearchText)));
+  }
+
+  /**
    * @return All contained SMP business card IDs. Never <code>null</code> but maybe empty.
    * @since 5.6.0
    */
@@ -138,4 +198,22 @@ public interface ISMPBusinessCardManager
    */
   @Nonnegative
   long getSMPBusinessCardCount ();
+
+  /**
+   * Get the number of business cards matching the provided search text.
+   *
+   * @param sSearchText
+   *        The search text to filter the business cards. May be <code>null</code> or empty in which
+   *        case all business cards are counted.
+   * @return The count of all matching business cards. Always &ge; 0.
+   * @since 8.2.1
+   */
+  @Nonnegative
+  default long getSMPBusinessCardCount (@Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getSMPBusinessCardCount ();
+
+    return getAllSMPBusinessCards ().getCount (x -> isMatchingSearchText (x, sSearchText));
+  }
 }

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/businesscard/ISMPBusinessCardManager.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/businesscard/ISMPBusinessCardManager.java
@@ -11,6 +11,7 @@
 package com.helger.phoss.smp.domain.businesscard;
 
 import java.util.Collection;
+import java.util.Comparator;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -23,6 +24,7 @@ import com.helger.base.state.EChange;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.collection.commons.ICommonsSet;
 import com.helger.peppolid.IParticipantIdentifier;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 
 /**
  * Manager for {@link ISMPBusinessCard} objects. Business card objects require a service group to be
@@ -79,6 +81,29 @@ public interface ISMPBusinessCardManager
   @NonNull
   @ReturnsMutableCopy
   ICommonsList <ISMPBusinessCard> getAllSMPBusinessCards ();
+
+  /**
+   * Get a single "page" of all contained SMP business cards, sorted by the business card ID. This
+   * method is meant to be used for server side pagination. Backends that support native paging
+   * should override this method.
+   *
+   * @param nStartIndex
+   *        The 0-based index of the first business card to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of business cards to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of business cards.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPBusinessCard> getAllSMPBusinessCards (@Nonnegative final int nStartIndex,
+                                                                  @Nonnegative final int nMaxCount)
+  {
+    return SMPPagingHelper.getPage (getAllSMPBusinessCards (),
+                                    Comparator.comparing (ISMPBusinessCard::getID),
+                                    nStartIndex,
+                                    nMaxCount);
+  }
 
   /**
    * @return All contained SMP business card IDs. Never <code>null</code> but maybe empty.

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/redirect/ISMPRedirectManager.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/redirect/ISMPRedirectManager.java
@@ -11,6 +11,7 @@
 package com.helger.phoss.smp.domain.redirect;
 
 import java.security.cert.X509Certificate;
+import java.util.Comparator;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -21,9 +22,11 @@ import com.helger.annotation.style.ReturnsMutableCopy;
 import com.helger.annotation.style.ReturnsMutableObject;
 import com.helger.base.callback.CallbackList;
 import com.helger.base.state.EChange;
+import com.helger.base.string.StringHelper;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 
 /**
  * Manager for {@link ISMPRedirect} objects. Redirect objects require a service
@@ -33,6 +36,17 @@ import com.helger.peppolid.IParticipantIdentifier;
  */
 public interface ISMPRedirectManager
 {
+  /**
+   * @return The comparator to be used for the server side pagination, to ensure a stable order
+   *         across single page requests.
+   */
+  @NonNull
+  private static Comparator <ISMPRedirect> _getDefaultComparator ()
+  {
+    return Comparator.comparing (ISMPRedirect::getServiceGroupID)
+                     .thenComparing (x -> x.getDocumentTypeIdentifier ().getURIEncoded ());
+  }
+
   /**
    * @return A non-<code>null</code> mutable list of callbacks.
    */
@@ -100,6 +114,56 @@ public interface ISMPRedirectManager
   ICommonsList <ISMPRedirect> getAllSMPRedirects ();
 
   /**
+   * Get a single "page" of all redirects, sorted by service group ID and document type ID. This
+   * method is meant to be used for server side pagination. Backends that support native paging
+   * should override this method.
+   *
+   * @param nStartIndex
+   *        The 0-based index of the first redirect to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of redirects to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of redirects.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPRedirect> getAllSMPRedirects (@Nonnegative final int nStartIndex,
+                                                          @Nonnegative final int nMaxCount)
+  {
+    return SMPPagingHelper.getPage (getAllSMPRedirects (), _getDefaultComparator (), nStartIndex, nMaxCount);
+  }
+
+  /**
+   * Get a single "page" of all redirects matching the provided search text, sorted by service group
+   * ID and document type ID. This method is meant to be used for server side pagination in
+   * combination with {@link #getSMPRedirectCount(String)}.
+   *
+   * @param sSearchText
+   *        The search text to filter the redirects. May be <code>null</code> or empty in which case
+   *        no filtering takes place.
+   * @param nStartIndex
+   *        The 0-based index of the first matching redirect to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of redirects to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of redirects.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPRedirect> getAllSMPRedirects (@Nullable final String sSearchText,
+                                                          @Nonnegative final int nStartIndex,
+                                                          @Nonnegative final int nMaxCount)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getAllSMPRedirects (nStartIndex, nMaxCount);
+
+    return SMPPagingHelper.getPage (getAllSMPRedirects ().getAll (x -> isMatchingSearchText (x, sSearchText)),
+                                    _getDefaultComparator (),
+                                    nStartIndex,
+                                    nMaxCount);
+  }
+
+  /**
    * Get all redirects of the passed service group.
    *
    * @param aParticipantID
@@ -116,6 +180,46 @@ public interface ISMPRedirectManager
    */
   @Nonnegative
   long getSMPRedirectCount ();
+
+  /**
+   * Get the number of redirects matching the provided search text.
+   *
+   * @param sSearchText
+   *        The search text to filter the redirects. May be <code>null</code> or empty in which case
+   *        all redirects are counted.
+   * @return The count of all matching redirects. Always &ge; 0.
+   * @since 8.2.1
+   */
+  @Nonnegative
+  default long getSMPRedirectCount (@Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getSMPRedirectCount ();
+
+    return getAllSMPRedirects ().getCount (x -> isMatchingSearchText (x, sSearchText));
+  }
+
+  /**
+   * Check if the provided redirect matches the provided search text. The participant ID, the
+   * document type ID and the target URL are checked.
+   *
+   * @param aRedirect
+   *        The redirect to check. May not be <code>null</code>.
+   * @param sSearchText
+   *        The search text to be searched. May be <code>null</code> or empty in which case
+   *        <code>true</code> is returned.
+   * @return <code>true</code> if the redirect matches, <code>false</code> if not.
+   * @since 8.2.1
+   */
+  static boolean isMatchingSearchText (@NonNull final ISMPRedirect aRedirect, @Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return true;
+
+    return SMPPagingHelper.matchesSearchText (aRedirect.getServiceGroupID (), sSearchText) ||
+           SMPPagingHelper.matchesSearchText (aRedirect.getDocumentTypeIdentifier ().getURIEncoded (), sSearchText) ||
+           SMPPagingHelper.matchesSearchText (aRedirect.getTargetHref (), sSearchText);
+  }
 
   /**
    * Find the redirect that matches the passed tuple of service group and

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/servicegroup/ISMPServiceGroupManager.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/servicegroup/ISMPServiceGroupManager.java
@@ -22,6 +22,7 @@ import com.helger.annotation.style.ReturnsMutableCopy;
 import com.helger.annotation.style.ReturnsMutableObject;
 import com.helger.base.callback.CallbackList;
 import com.helger.base.state.EChange;
+import com.helger.base.string.StringHelper;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.collection.commons.ICommonsSet;
 import com.helger.peppolid.IParticipantIdentifier;
@@ -202,6 +203,57 @@ public interface ISMPServiceGroupManager extends ISMPServiceGroupProvider
   }
 
   /**
+   * Get a single "page" of all service groups matching the provided search text, sorted by the
+   * participant identifier. This method is meant to be used for server side pagination in
+   * combination with {@link #getSMPServiceGroupCount(String)}.
+   *
+   * @param sSearchText
+   *        The search text to filter the service groups. May be <code>null</code> or empty in which
+   *        case no filtering takes place.
+   * @param nStartIndex
+   *        The 0-based index of the first matching service group to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of service groups to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of service groups.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPServiceGroup> getAllSMPServiceGroups (@Nullable final String sSearchText,
+                                                                  @Nonnegative final int nStartIndex,
+                                                                  @Nonnegative final int nMaxCount)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getAllSMPServiceGroups (nStartIndex, nMaxCount);
+
+    return SMPPagingHelper.getPage (getAllSMPServiceGroups ().getAll (x -> isMatchingSearchText (x, sSearchText)),
+                                    Comparator.comparing (ISMPServiceGroup::getID),
+                                    nStartIndex,
+                                    nMaxCount);
+  }
+
+  /**
+   * Check if the provided service group matches the provided search text. The participant ID is
+   * checked.
+   *
+   * @param aServiceGroup
+   *        The service group to check. May not be <code>null</code>.
+   * @param sSearchText
+   *        The search text to be searched. May be <code>null</code> or empty in which case
+   *        <code>true</code> is returned.
+   * @return <code>true</code> if the service group matches, <code>false</code> if not.
+   * @since 8.2.1
+   */
+  static boolean isMatchingSearchText (@NonNull final ISMPServiceGroup aServiceGroup,
+                                       @Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return true;
+
+    return SMPPagingHelper.matchesSearchText (aServiceGroup.getID (), sSearchText);
+  }
+
+  /**
    * @return A non-<code>null</code> but maybe empty set of all contained
    *         service group IDs.
    * @since 5.6.0
@@ -249,4 +301,23 @@ public interface ISMPServiceGroupManager extends ISMPServiceGroupProvider
    */
   @CheckForSigned
   long getSMPServiceGroupCount ();
+
+  /**
+   * Get the number of service groups matching the provided search text.
+   *
+   * @param sSearchText
+   *        The search text to filter the service groups. May be <code>null</code> or empty in which
+   *        case all service groups are counted.
+   * @return The number of matching service groups. May be &lt; 0 in case there was an error
+   *         querying (e.g. because of missing SQL backend).
+   * @since 8.2.1
+   */
+  @CheckForSigned
+  default long getSMPServiceGroupCount (@Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getSMPServiceGroupCount ();
+
+    return getAllSMPServiceGroups ().getCount (x -> isMatchingSearchText (x, sSearchText));
+  }
 }

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/servicegroup/ISMPServiceGroupManager.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/servicegroup/ISMPServiceGroupManager.java
@@ -10,6 +10,8 @@
  */
 package com.helger.phoss.smp.domain.servicegroup;
 
+import java.util.Comparator;
+
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -23,6 +25,7 @@ import com.helger.base.state.EChange;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.collection.commons.ICommonsSet;
 import com.helger.peppolid.IParticipantIdentifier;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 import com.helger.phoss.smp.domain.redirect.ISMPRedirectManager;
 import com.helger.phoss.smp.domain.serviceinfo.ISMPServiceInformationManager;
 import com.helger.phoss.smp.domain.sgprops.SGCustomPropertyList;
@@ -172,6 +175,31 @@ public interface ISMPServiceGroupManager extends ISMPServiceGroupProvider
   @NonNull
   @ReturnsMutableCopy
   ICommonsList <ISMPServiceGroup> getAllSMPServiceGroups ();
+
+  /**
+   * Get a single "page" of all contained service groups, sorted by the
+   * participant identifier. This method is meant to be used for server side
+   * pagination. Backends that support native paging should override this
+   * method.
+   *
+   * @param nStartIndex
+   *        The 0-based index of the first service group to be returned. Must be
+   *        &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of service groups to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of service groups.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPServiceGroup> getAllSMPServiceGroups (@Nonnegative final int nStartIndex,
+                                                                  @Nonnegative final int nMaxCount)
+  {
+    return SMPPagingHelper.getPage (getAllSMPServiceGroups (),
+                                    Comparator.comparing (ISMPServiceGroup::getID),
+                                    nStartIndex,
+                                    nMaxCount);
+  }
 
   /**
    * @return A non-<code>null</code> but maybe empty set of all contained

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/serviceinfo/ISMPServiceInformationManager.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/serviceinfo/ISMPServiceInformationManager.java
@@ -10,6 +10,7 @@
  */
 package com.helger.phoss.smp.domain.serviceinfo;
 
+import java.util.Comparator;
 import java.util.function.Consumer;
 
 import org.jspecify.annotations.NonNull;
@@ -26,6 +27,7 @@ import com.helger.collection.commons.ICommonsMap;
 import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.IProcessIdentifier;
+import com.helger.phoss.smp.domain.SMPPagingHelper;
 
 /**
  * Manager for {@link ISMPServiceInformation} objects. Service information objects require a service
@@ -124,6 +126,30 @@ public interface ISMPServiceInformationManager
   @NonNull
   @ReturnsMutableCopy
   ICommonsList <ISMPServiceInformation> getAllSMPServiceInformation ();
+
+  /**
+   * Get a single "page" of all service information objects, sorted by service group ID and document
+   * type ID. This method is meant to be used for server side pagination. Backends that support
+   * native paging should override this method.
+   *
+   * @param nStartIndex
+   *        The 0-based index of the first service information object to be returned. Must be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of service information objects to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of service information objects.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPServiceInformation> getAllSMPServiceInformation (@Nonnegative final int nStartIndex,
+                                                                             @Nonnegative final int nMaxCount)
+  {
+    return SMPPagingHelper.getPage (getAllSMPServiceInformation (),
+                                    Comparator.comparing (ISMPServiceInformation::getServiceGroupID)
+                                              .thenComparing (x -> x.getDocumentTypeIdentifier ().getURIEncoded ()),
+                                    nStartIndex,
+                                    nMaxCount);
+  }
 
   /**
    * Iterate each Service Information element and invoke the provided consumer for it.

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/serviceinfo/ISMPServiceInformationManager.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/serviceinfo/ISMPServiceInformationManager.java
@@ -21,6 +21,7 @@ import com.helger.annotation.style.ReturnsMutableCopy;
 import com.helger.annotation.style.ReturnsMutableObject;
 import com.helger.base.callback.CallbackList;
 import com.helger.base.state.EChange;
+import com.helger.base.string.StringHelper;
 import com.helger.base.state.ESuccess;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.collection.commons.ICommonsMap;
@@ -152,6 +153,38 @@ public interface ISMPServiceInformationManager
   }
 
   /**
+   * Get a single "page" of all service information objects matching the provided search text,
+   * sorted by service group ID and document type ID. This method is meant to be used for server
+   * side pagination in combination with {@link #getSMPServiceInformationCount(String)}.
+   *
+   * @param sSearchText
+   *        The search text to filter the service information objects. May be <code>null</code> or
+   *        empty in which case no filtering takes place.
+   * @param nStartIndex
+   *        The 0-based index of the first matching service information object to be returned. Must
+   *        be &ge; 0.
+   * @param nMaxCount
+   *        The maximum number of service information objects to be returned. Must be &ge; 0.
+   * @return A non-<code>null</code> but maybe empty list of service information objects.
+   * @since 8.2.1
+   */
+  @NonNull
+  @ReturnsMutableCopy
+  default ICommonsList <ISMPServiceInformation> getAllSMPServiceInformation (@Nullable final String sSearchText,
+                                                                             @Nonnegative final int nStartIndex,
+                                                                             @Nonnegative final int nMaxCount)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getAllSMPServiceInformation (nStartIndex, nMaxCount);
+
+    return SMPPagingHelper.getPage (getAllSMPServiceInformation ().getAll (x -> isMatchingSearchText (x, sSearchText)),
+                                    Comparator.comparing (ISMPServiceInformation::getServiceGroupID)
+                                              .thenComparing (x -> x.getDocumentTypeIdentifier ().getURIEncoded ()),
+                                    nStartIndex,
+                                    nMaxCount);
+  }
+
+  /**
    * Iterate each Service Information element and invoke the provided consumer for it.
    *
    * @param aConsumer
@@ -165,6 +198,46 @@ public interface ISMPServiceInformationManager
    */
   @Nonnegative
   long getSMPServiceInformationCount ();
+
+  /**
+   * Get the number of service information objects matching the provided search text.
+   *
+   * @param sSearchText
+   *        The search text to filter the service information objects. May be <code>null</code> or
+   *        empty in which case all service information objects are counted.
+   * @return The count of all matching service information objects. Always &ge; 0.
+   * @since 8.2.1
+   */
+  @Nonnegative
+  default long getSMPServiceInformationCount (@Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return getSMPServiceInformationCount ();
+
+    return getAllSMPServiceInformation ().getCount (x -> isMatchingSearchText (x, sSearchText));
+  }
+
+  /**
+   * Check if the provided service information object matches the provided search text. The
+   * participant ID and the document type ID are checked.
+   *
+   * @param aServiceInfo
+   *        The service information object to check. May not be <code>null</code>.
+   * @param sSearchText
+   *        The search text to be searched. May be <code>null</code> or empty in which case
+   *        <code>true</code> is returned.
+   * @return <code>true</code> if the service information object matches, <code>false</code> if not.
+   * @since 8.2.1
+   */
+  static boolean isMatchingSearchText (@NonNull final ISMPServiceInformation aServiceInfo,
+                                       @Nullable final String sSearchText)
+  {
+    if (StringHelper.isEmpty (sSearchText))
+      return true;
+
+    return SMPPagingHelper.matchesSearchText (aServiceInfo.getServiceGroupID (), sSearchText) ||
+           SMPPagingHelper.matchesSearchText (aServiceInfo.getDocumentTypeIdentifier ().getURIEncoded (), sSearchText);
+  }
 
   /**
    * Get all service information objects that belong to the provided service group.

--- a/phoss-smp-backend/src/test/java/com/helger/phoss/smp/domain/SMPPagingHelperTest.java
+++ b/phoss-smp-backend/src/test/java/com/helger/phoss/smp/domain/SMPPagingHelperTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * The Original Code is Copyright The Peppol project (http://www.peppol.eu)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.helger.phoss.smp.domain;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Comparator;
+
+import org.junit.Test;
+
+import com.helger.collection.commons.CommonsArrayList;
+import com.helger.collection.commons.ICommonsList;
+
+/**
+ * Test class for class {@link SMPPagingHelper}.
+ *
+ * @author Philip Helger
+ */
+public final class SMPPagingHelperTest
+{
+  private static ICommonsList <String> _list ()
+  {
+    return new CommonsArrayList <> ("d", "b", "e", "a", "c");
+  }
+
+  @Test
+  public void testGetPage ()
+  {
+    final Comparator <String> aComp = Comparator.naturalOrder ();
+
+    // First page
+    assertEquals (new CommonsArrayList <> ("a", "b"), SMPPagingHelper.getPage (_list (), aComp, 0, 2));
+    // Second page
+    assertEquals (new CommonsArrayList <> ("c", "d"), SMPPagingHelper.getPage (_list (), aComp, 2, 2));
+    // Last page - less elements than the page size
+    assertEquals (new CommonsArrayList <> ("e"), SMPPagingHelper.getPage (_list (), aComp, 4, 2));
+    // Start index out of range
+    assertEquals (new CommonsArrayList <> (), SMPPagingHelper.getPage (_list (), aComp, 5, 2));
+    assertEquals (new CommonsArrayList <> (), SMPPagingHelper.getPage (_list (), aComp, 100, 2));
+    // Empty page
+    assertEquals (new CommonsArrayList <> (), SMPPagingHelper.getPage (_list (), aComp, 0, 0));
+    // Page larger than the list
+    assertEquals (new CommonsArrayList <> ("a", "b", "c", "d", "e"),
+                  SMPPagingHelper.getPage (_list (), aComp, 0, 100));
+    // Empty list
+    assertEquals (new CommonsArrayList <> (),
+                  SMPPagingHelper.getPage (new CommonsArrayList <String> (), aComp, 0, 10));
+  }
+
+  @Test
+  public void testInvalidParams ()
+  {
+    try
+    {
+      SMPPagingHelper.checkPagingParams (-1, 10);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {
+      // expected
+    }
+
+    try
+    {
+      SMPPagingHelper.checkPagingParams (0, -1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {
+      // expected
+    }
+  }
+}

--- a/phoss-smp-backend/src/test/java/com/helger/phoss/smp/domain/SMPPagingHelperTest.java
+++ b/phoss-smp-backend/src/test/java/com/helger/phoss/smp/domain/SMPPagingHelperTest.java
@@ -11,6 +11,8 @@
 package com.helger.phoss.smp.domain;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Comparator;
@@ -54,6 +56,26 @@ public final class SMPPagingHelperTest
     // Empty list
     assertEquals (new CommonsArrayList <> (),
                   SMPPagingHelper.getPage (new CommonsArrayList <String> (), aComp, 0, 10));
+  }
+
+  @Test
+  public void testMatchesSearchText ()
+  {
+    // Empty search text matches everything
+    assertTrue (SMPPagingHelper.matchesSearchText ("anything", null));
+    assertTrue (SMPPagingHelper.matchesSearchText ("anything", ""));
+    assertTrue (SMPPagingHelper.matchesSearchText (null, null));
+
+    // Case insensitive "contains"
+    assertTrue (SMPPagingHelper.matchesSearchText ("iso6523-actorid-upis::9915:test", "9915"));
+    assertTrue (SMPPagingHelper.matchesSearchText ("iso6523-actorid-upis::9915:test", "TEST"));
+    assertTrue (SMPPagingHelper.matchesSearchText ("ISO6523-actorid-upis::9915:test", "iso6523"));
+    assertTrue (SMPPagingHelper.matchesSearchText ("abc", "abc"));
+
+    // No match
+    assertFalse (SMPPagingHelper.matchesSearchText ("iso6523-actorid-upis::9915:test", "9916"));
+    assertFalse (SMPPagingHelper.matchesSearchText (null, "abc"));
+    assertFalse (SMPPagingHelper.matchesSearchText ("", "abc"));
   }
 
   @Test

--- a/phoss-smp-webapp-mongodb/src/main/resources/application.properties
+++ b/phoss-smp-webapp-mongodb/src/main/resources/application.properties
@@ -43,6 +43,9 @@ webapp.startpage.participants.none = false
 # Don't show content of extensions by default on start page
 webapp.startpage.extensions.show = false
 
+# The number of entries shown per page on the paginated list pages
+webapp.pagination.pagesize = 100
+
 # The name of the Directory implementation
 webapp.directory.name = Peppol Directory
 

--- a/phoss-smp-webapp-mongodb/src/main/resources/application.properties
+++ b/phoss-smp-webapp-mongodb/src/main/resources/application.properties
@@ -44,7 +44,7 @@ webapp.startpage.participants.none = false
 webapp.startpage.extensions.show = false
 
 # The number of entries shown per page on the paginated list pages
-webapp.pagination.pagesize = 100
+webapp.pagination.pagesize = 25
 
 # The name of the Directory implementation
 webapp.directory.name = Peppol Directory

--- a/phoss-smp-webapp-sql/src/main/resources/application.properties
+++ b/phoss-smp-webapp-sql/src/main/resources/application.properties
@@ -43,6 +43,9 @@ webapp.startpage.participants.none = false
 # Don't show content of extensions by default on start page
 webapp.startpage.extensions.show = false
 
+# The number of entries shown per page on the paginated list pages
+webapp.pagination.pagesize = 100
+
 # The name of the Directory implementation
 webapp.directory.name = Peppol Directory
 

--- a/phoss-smp-webapp-sql/src/main/resources/application.properties
+++ b/phoss-smp-webapp-sql/src/main/resources/application.properties
@@ -44,7 +44,7 @@ webapp.startpage.participants.none = false
 webapp.startpage.extensions.show = false
 
 # The number of entries shown per page on the paginated list pages
-webapp.pagination.pagesize = 100
+webapp.pagination.pagesize = 25
 
 # The name of the Directory implementation
 webapp.directory.name = Peppol Directory

--- a/phoss-smp-webapp-xml/src/main/resources/application.properties
+++ b/phoss-smp-webapp-xml/src/main/resources/application.properties
@@ -43,6 +43,9 @@ webapp.startpage.participants.none = false
 # Don't show content of extensions by default on start page
 webapp.startpage.extensions.show = false
 
+# The number of entries shown per page on the paginated list pages
+webapp.pagination.pagesize = 100
+
 # The name of the Directory implementation
 webapp.directory.name = Peppol Directory
 

--- a/phoss-smp-webapp-xml/src/main/resources/application.properties
+++ b/phoss-smp-webapp-xml/src/main/resources/application.properties
@@ -44,7 +44,7 @@ webapp.startpage.participants.none = false
 webapp.startpage.extensions.show = false
 
 # The number of entries shown per page on the paginated list pages
-webapp.pagination.pagesize = 100
+webapp.pagination.pagesize = 25
 
 # The name of the Directory implementation
 webapp.directory.name = Peppol Directory

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/app/SMPWebAppConfiguration.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/app/SMPWebAppConfiguration.java
@@ -44,7 +44,7 @@ public final class SMPWebAppConfiguration extends AbstractGlobalSingleton
   public static final String WEBAPP_KEY_GLOBAL_PRODUCTION = "global.production";
 
   /** The default number of entries shown per page on paginated list pages */
-  public static final int DEFAULT_PAGINATION_PAGE_SIZE = 100;
+  public static final int DEFAULT_PAGINATION_PAGE_SIZE = 25;
 
   /**
    * @deprecated Only called via reflection

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/app/SMPWebAppConfiguration.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/app/SMPWebAppConfiguration.java
@@ -20,6 +20,7 @@ import java.net.URL;
 
 import org.jspecify.annotations.NonNull;
 
+import com.helger.annotation.Nonnegative;
 import com.helger.annotation.style.UsedViaReflection;
 import com.helger.base.debug.GlobalDebug;
 import com.helger.base.string.StringHelper;
@@ -41,6 +42,9 @@ public final class SMPWebAppConfiguration extends AbstractGlobalSingleton
 {
   public static final String WEBAPP_KEY_GLOBAL_DEBUG = "global.debug";
   public static final String WEBAPP_KEY_GLOBAL_PRODUCTION = "global.production";
+
+  /** The default number of entries shown per page on paginated list pages */
+  public static final int DEFAULT_PAGINATION_PAGE_SIZE = 100;
 
   /**
    * @deprecated Only called via reflection
@@ -150,6 +154,18 @@ public final class SMPWebAppConfiguration extends AbstractGlobalSingleton
   public static boolean isStartPageExtensionsShow ()
   {
     return _getConfig ().getAsBoolean ("webapp.startpage.extensions.show", false);
+  }
+
+  /**
+   * @return The default number of entries shown per page on the paginated list pages. Always &gt;
+   *         0. The default value is {@value #DEFAULT_PAGINATION_PAGE_SIZE}.
+   * @since 8.2.1
+   */
+  @Nonnegative
+  public static int getPaginationPageSize ()
+  {
+    final int ret = _getConfig ().getAsInt ("webapp.pagination.pagesize", DEFAULT_PAGINATION_PAGE_SIZE);
+    return ret > 0 ? ret : DEFAULT_PAGINATION_PAGE_SIZE;
   }
 
   /**

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/SMPPagination.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/SMPPagination.java
@@ -21,9 +21,15 @@ import org.jspecify.annotations.Nullable;
 
 import com.helger.annotation.Nonnegative;
 import com.helger.base.enforce.ValueEnforcer;
+import com.helger.base.string.StringHelper;
 import com.helger.html.css.DefaultCSSClassProvider;
 import com.helger.html.css.ICSSClassProvider;
 import com.helger.html.hc.IHCNode;
+import com.helger.html.hc.html.forms.EHCFormMethod;
+import com.helger.html.hc.html.forms.HCButton_Submit;
+import com.helger.html.hc.html.forms.HCEdit;
+import com.helger.html.hc.html.forms.HCForm;
+import com.helger.html.hc.html.forms.HCHiddenField;
 import com.helger.html.hc.html.grouping.HCLI;
 import com.helger.html.hc.html.grouping.HCUL;
 import com.helger.html.hc.html.sections.HCNav;
@@ -34,7 +40,7 @@ import com.helger.html.hc.impl.HCTextNode;
 import com.helger.phoss.smp.app.SMPWebAppConfiguration;
 import com.helger.photon.uicore.page.IWebPageExecutionContext;
 import com.helger.photon.uictrls.datatables.DataTables;
-import com.helger.url.ISimpleURL;
+import com.helger.url.param.URLParameter;
 import com.helger.url.SimpleURL;
 
 /**
@@ -51,6 +57,8 @@ public class SMPPagination
   public static final String PARAM_PAGE_INDEX = "pageindex";
   /** Name of the request parameter with the number of items per page */
   public static final String PARAM_PAGE_SIZE = "pagesize";
+  /** Name of the request parameter with the search text to filter the items */
+  public static final String PARAM_SEARCH_TEXT = "searchtext";
 
   /** The minimum allowed page size */
   public static final int MIN_PAGE_SIZE = 1;
@@ -63,8 +71,18 @@ public class SMPPagination
   private static final ICSSClassProvider CSS_CLASS_PAGE_LINK = DefaultCSSClassProvider.create ("page-link");
   private static final ICSSClassProvider CSS_CLASS_ACTIVE = DefaultCSSClassProvider.create ("active");
   private static final ICSSClassProvider CSS_CLASS_DISABLED = DefaultCSSClassProvider.create ("disabled");
+  private static final ICSSClassProvider CSS_CLASS_D_FLEX = DefaultCSSClassProvider.create ("d-flex");
+  private static final ICSSClassProvider CSS_CLASS_ALIGN_ITEMS_CENTER = DefaultCSSClassProvider.create ("align-items-center");
+  private static final ICSSClassProvider CSS_CLASS_GAP_2 = DefaultCSSClassProvider.create ("gap-2");
+  private static final ICSSClassProvider CSS_CLASS_MB_2 = DefaultCSSClassProvider.create ("mb-2");
+  private static final ICSSClassProvider CSS_CLASS_FORM_CONTROL = DefaultCSSClassProvider.create ("form-control");
+  private static final ICSSClassProvider CSS_CLASS_W_AUTO = DefaultCSSClassProvider.create ("w-auto");
+  private static final ICSSClassProvider CSS_CLASS_BTN = DefaultCSSClassProvider.create ("btn");
+  private static final ICSSClassProvider CSS_CLASS_BTN_SECONDARY = DefaultCSSClassProvider.create ("btn-secondary");
+  private static final ICSSClassProvider CSS_CLASS_ME_3 = DefaultCSSClassProvider.create ("me-3");
 
-  private final ISimpleURL m_aBaseURL;
+  private final SimpleURL m_aBaseURL;
+  private final String m_sSearchText;
   private final long m_nTotalCount;
   private final int m_nPageSize;
   private final int m_nPageIndex;
@@ -76,14 +94,21 @@ public class SMPPagination
    *        The web page execution context to retrieve the request parameters from. May not be
    *        <code>null</code>.
    * @param nTotalCount
-   *        The total number of items to be paginated. If the value is &lt; 0 (e.g. because the
-   *        backend could not determine it) it is treated as 0.
+   *        The total number of items to be paginated, taking the current search text into account.
+   *        If the value is &lt; 0 (e.g. because the backend could not determine it) it is treated
+   *        as 0.
+   * @see #getSearchText(IWebPageExecutionContext)
    */
   public SMPPagination (@NonNull final IWebPageExecutionContext aWPEC, final long nTotalCount)
   {
     ValueEnforcer.notNull (aWPEC, "WPEC");
 
-    m_aBaseURL = aWPEC.getSelfHref ();
+    // Remove the pagination parameters from the base URL, because they are
+    // added explicitly to each created link
+    m_aBaseURL = new SimpleURL (aWPEC.getSelfHref ()).withParams (x -> x.removeIf (p -> p.hasName (PARAM_PAGE_INDEX) ||
+                                                                                        p.hasName (PARAM_PAGE_SIZE) ||
+                                                                                        p.hasName (PARAM_SEARCH_TEXT)));
+    m_sSearchText = getSearchText (aWPEC);
     m_nTotalCount = Math.max (nTotalCount, 0);
 
     // Determine the page size
@@ -133,6 +158,16 @@ public class SMPPagination
   }
 
   /**
+   * @return The search text to filter the shown items. May be <code>null</code> or empty, if no
+   *         filtering should take place.
+   */
+  @Nullable
+  public final String getSearchText ()
+  {
+    return m_sSearchText;
+  }
+
+  /**
    * @return The total number of pages. Always &ge; 1.
    */
   @Nonnegative
@@ -153,15 +188,25 @@ public class SMPPagination
   }
 
   @NonNull
-  private ISimpleURL _getPageURL (@Nonnegative final int nPageIndex, @Nonnegative final int nPageSize)
+  private SimpleURL _getPageURL (@Nonnegative final int nPageIndex, @Nonnegative final int nPageSize)
   {
-    return new SimpleURL (m_aBaseURL).add (PARAM_PAGE_INDEX, nPageIndex).add (PARAM_PAGE_SIZE, nPageSize);
+    final SimpleURL ret = _getPageURLNoSearch (nPageIndex, nPageSize);
+    if (StringHelper.isNotEmpty (m_sSearchText))
+      ret.add (PARAM_SEARCH_TEXT, m_sSearchText);
+    return ret;
+  }
+
+  @NonNull
+  private SimpleURL _getPageURLNoSearch (@Nonnegative final int nPageIndex, @Nonnegative final int nPageSize)
+  {
+    return new SimpleURL (m_aBaseURL).add (PARAM_PAGE_INDEX, nPageIndex)
+                                     .add (PARAM_PAGE_SIZE, nPageSize);
   }
 
   @NonNull
   private HCLI _createItem (@NonNull final HCUL aUL,
                             @NonNull final String sText,
-                            @Nullable final ISimpleURL aTargetURL,
+                            @Nullable final SimpleURL aTargetURL,
                             final boolean bActive)
   {
     final HCLI aLI = aUL.addAndReturnItem ((IHCNode) null).addClass (CSS_CLASS_PAGE_ITEM);
@@ -178,9 +223,10 @@ public class SMPPagination
   }
 
   /**
-   * Align the provided DataTables with the server side pagination: the client side page length is
-   * set to the server side page size, so that the client side pagination never kicks in, and the
-   * client side page length selection is hidden, because the server side one is used instead.
+   * Align the provided DataTables with the server side pagination: all client side controls that
+   * are provided by the server side pagination as well (paging, page length selection, the
+   * information on the shown entries and the search field) are disabled, so that they are not shown
+   * twice and so that they don't only work on the entries of the current page.
    *
    * @param aDataTables
    *        The DataTables to be modified. May not be <code>null</code>.
@@ -190,12 +236,65 @@ public class SMPPagination
   public DataTables applyTo (@NonNull final DataTables aDataTables)
   {
     ValueEnforcer.notNull (aDataTables, "DataTables");
-    return aDataTables.setPageLength (m_nPageSize).setLengthChange (false);
+    return aDataTables.setPageLength (m_nPageSize)
+                      .setPaging (false)
+                      .setLengthChange (false)
+                      .setInfo (false)
+                      .setSearching (false);
   }
 
   /**
-   * Create the UI of the pagination. If all items fit onto a single page, only the item count is
-   * shown.
+   * Get the search text of the current request. This is needed to determine the total number of
+   * matching items, before this object can be created.
+   *
+   * @param aWPEC
+   *        The web page execution context to retrieve the request parameter from. May not be
+   *        <code>null</code>.
+   * @return The search text to be used for filtering. May be <code>null</code> or empty.
+   */
+  @Nullable
+  public static String getSearchText (@NonNull final IWebPageExecutionContext aWPEC)
+  {
+    ValueEnforcer.notNull (aWPEC, "WPEC");
+    return StringHelper.trim (aWPEC.params ().getAsString (PARAM_SEARCH_TEXT));
+  }
+
+  /**
+   * Create the search field. Because the filtering happens on the server side, a simple GET form is
+   * used, that resets the page index, because the number of matching entries changes.
+   *
+   * @return The created UI node. Never <code>null</code>.
+   */
+  @NonNull
+  private IHCNode _createSearchUI ()
+  {
+    final HCForm aForm = new HCForm (m_aBaseURL).setMethod (EHCFormMethod.GET)
+                                                .addClasses (CSS_CLASS_D_FLEX,
+                                                             CSS_CLASS_ALIGN_ITEMS_CENTER,
+                                                             CSS_CLASS_GAP_2,
+                                                             CSS_CLASS_MB_2);
+
+    // A GET form drops the query parameters of the action URL, so all existing
+    // parameters must be added as hidden fields
+    for (final URLParameter aParam : m_aBaseURL.params ())
+      aForm.addChild (new HCHiddenField (aParam.getName (), aParam.getValue ()));
+
+    // Always start with the first page again, because the number of matching
+    // entries changes
+    aForm.addChild (new HCHiddenField (PARAM_PAGE_INDEX, 0));
+    aForm.addChild (new HCHiddenField (PARAM_PAGE_SIZE, m_nPageSize));
+    aForm.addChild (new HCEdit (PARAM_SEARCH_TEXT).setValue (m_sSearchText)
+                                                  .setPlaceholder ("Search")
+                                                  .addClasses (CSS_CLASS_FORM_CONTROL, CSS_CLASS_W_AUTO));
+    aForm.addChild (new HCButton_Submit ("Search").addClasses (CSS_CLASS_BTN, CSS_CLASS_BTN_SECONDARY));
+    if (StringHelper.isNotEmpty (m_sSearchText))
+      aForm.addChild (new HCA (_getPageURLNoSearch (0, m_nPageSize)).addChild ("Clear search"));
+    return aForm;
+  }
+
+  /**
+   * Create the UI of the pagination. If all items fit onto a single page, only the item count and
+   * the search field are shown.
    *
    * @return The created UI node. Never <code>null</code>.
    */
@@ -205,18 +304,20 @@ public class SMPPagination
     final HCNodeList ret = new HCNodeList ();
     final int nPageCount = getPageCount ();
 
+    ret.addChild (_createSearchUI ());
+
     // Textual information on the currently shown items
     {
       final String sInfo;
       if (m_nTotalCount == 0)
-        sInfo = "No entry found";
+        sInfo = StringHelper.isNotEmpty (m_sSearchText) ? "No matching entry found" : "No entry found";
       else
       {
         final long nFirst = getFirstItemIndex () + 1L;
         final long nLast = Math.min (nFirst + m_nPageSize - 1L, m_nTotalCount);
         sInfo = "Showing entries " + nFirst + " to " + nLast + " of " + m_nTotalCount;
       }
-      ret.addChild (new HCSpan ().addClass (DefaultCSSClassProvider.create ("me-3")).addChild (sInfo));
+      ret.addChild (new HCSpan ().addClass (CSS_CLASS_ME_3).addChild (sInfo));
     }
 
     // The page size selector

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/SMPPagination.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/SMPPagination.java
@@ -79,6 +79,9 @@ public class SMPPagination
   private static final ICSSClassProvider CSS_CLASS_W_AUTO = DefaultCSSClassProvider.create ("w-auto");
   private static final ICSSClassProvider CSS_CLASS_BTN = DefaultCSSClassProvider.create ("btn");
   private static final ICSSClassProvider CSS_CLASS_BTN_SECONDARY = DefaultCSSClassProvider.create ("btn-secondary");
+  private static final ICSSClassProvider CSS_CLASS_BTN_OUTLINE_SECONDARY = DefaultCSSClassProvider.create ("btn-outline-secondary");
+  private static final ICSSClassProvider CSS_CLASS_BTN_SM = DefaultCSSClassProvider.create ("btn-sm");
+  private static final ICSSClassProvider CSS_CLASS_BTN_GROUP = DefaultCSSClassProvider.create ("btn-group");
   private static final ICSSClassProvider CSS_CLASS_ME_3 = DefaultCSSClassProvider.create ("me-3");
 
   private final SimpleURL m_aBaseURL;
@@ -288,7 +291,9 @@ public class SMPPagination
                                                   .addClasses (CSS_CLASS_FORM_CONTROL, CSS_CLASS_W_AUTO));
     aForm.addChild (new HCButton_Submit ("Search").addClasses (CSS_CLASS_BTN, CSS_CLASS_BTN_SECONDARY));
     if (StringHelper.isNotEmpty (m_sSearchText))
-      aForm.addChild (new HCA (_getPageURLNoSearch (0, m_nPageSize)).addChild ("Clear search"));
+      aForm.addChild (new HCA (_getPageURLNoSearch (0, m_nPageSize)).addClasses (CSS_CLASS_BTN,
+                                                                                 CSS_CLASS_BTN_OUTLINE_SECONDARY)
+                                                                    .addChild ("Clear search"));
     return aForm;
   }
 
@@ -324,23 +329,27 @@ public class SMPPagination
     {
       final HCNodeList aPageSizes = new HCNodeList ();
       aPageSizes.addChild (new HCTextNode ("Entries per page: "));
-      boolean bFirst = true;
+
+      final HCSpan aButtonGroup = new HCSpan ().addClass (CSS_CLASS_BTN_GROUP);
       for (final int nPageSize : PAGE_SIZES)
       {
-        if (bFirst)
-          bFirst = false;
-        else
-          aPageSizes.addChild (new HCTextNode (" | "));
-
         final String sText = Integer.toString (nPageSize);
         if (nPageSize == m_nPageSize)
-          aPageSizes.addChild (new HCSpan ().addChild (sText));
+          aButtonGroup.addChild (new HCSpan ().addClasses (CSS_CLASS_BTN,
+                                                           CSS_CLASS_BTN_SECONDARY,
+                                                           CSS_CLASS_BTN_SM,
+                                                           CSS_CLASS_ACTIVE,
+                                                           CSS_CLASS_DISABLED).addChild (sText));
         else
         {
           // Start with the first page again, because the offsets change
-          aPageSizes.addChild (new HCA (_getPageURL (0, nPageSize)).addChild (sText));
+          aButtonGroup.addChild (new HCA (_getPageURL (0, nPageSize)).addClasses (CSS_CLASS_BTN,
+                                                                                  CSS_CLASS_BTN_OUTLINE_SECONDARY,
+                                                                                  CSS_CLASS_BTN_SM)
+                                                                     .addChild (sText));
         }
       }
+      aPageSizes.addChild (aButtonGroup);
       ret.addChild (aPageSizes);
     }
 

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/SMPPagination.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/SMPPagination.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.ui;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.html.css.DefaultCSSClassProvider;
+import com.helger.html.css.ICSSClassProvider;
+import com.helger.html.hc.IHCNode;
+import com.helger.html.hc.html.grouping.HCLI;
+import com.helger.html.hc.html.grouping.HCUL;
+import com.helger.html.hc.html.sections.HCNav;
+import com.helger.html.hc.html.textlevel.HCA;
+import com.helger.html.hc.html.textlevel.HCSpan;
+import com.helger.html.hc.impl.HCNodeList;
+import com.helger.html.hc.impl.HCTextNode;
+import com.helger.phoss.smp.app.SMPWebAppConfiguration;
+import com.helger.photon.uicore.page.IWebPageExecutionContext;
+import com.helger.photon.uictrls.datatables.DataTables;
+import com.helger.url.ISimpleURL;
+import com.helger.url.SimpleURL;
+
+/**
+ * Represents the state of the server side pagination of a single list page. The current page index
+ * and the current page size are taken from the request parameters, so that every page can be
+ * bookmarked.
+ *
+ * @author Philip Helger
+ * @since 8.2.1
+ */
+public class SMPPagination
+{
+  /** Name of the request parameter with the 0-based index of the current page */
+  public static final String PARAM_PAGE_INDEX = "pageindex";
+  /** Name of the request parameter with the number of items per page */
+  public static final String PARAM_PAGE_SIZE = "pagesize";
+
+  /** The minimum allowed page size */
+  public static final int MIN_PAGE_SIZE = 1;
+  /** The maximum allowed page size */
+  public static final int MAX_PAGE_SIZE = 10_000;
+
+  private static final int [] PAGE_SIZES = { 25, 50, 100, 250, 1_000 };
+  private static final ICSSClassProvider CSS_CLASS_PAGINATION = DefaultCSSClassProvider.create ("pagination");
+  private static final ICSSClassProvider CSS_CLASS_PAGE_ITEM = DefaultCSSClassProvider.create ("page-item");
+  private static final ICSSClassProvider CSS_CLASS_PAGE_LINK = DefaultCSSClassProvider.create ("page-link");
+  private static final ICSSClassProvider CSS_CLASS_ACTIVE = DefaultCSSClassProvider.create ("active");
+  private static final ICSSClassProvider CSS_CLASS_DISABLED = DefaultCSSClassProvider.create ("disabled");
+
+  private final ISimpleURL m_aBaseURL;
+  private final long m_nTotalCount;
+  private final int m_nPageSize;
+  private final int m_nPageIndex;
+
+  /**
+   * Constructor.
+   *
+   * @param aWPEC
+   *        The web page execution context to retrieve the request parameters from. May not be
+   *        <code>null</code>.
+   * @param nTotalCount
+   *        The total number of items to be paginated. If the value is &lt; 0 (e.g. because the
+   *        backend could not determine it) it is treated as 0.
+   */
+  public SMPPagination (@NonNull final IWebPageExecutionContext aWPEC, final long nTotalCount)
+  {
+    ValueEnforcer.notNull (aWPEC, "WPEC");
+
+    m_aBaseURL = aWPEC.getSelfHref ();
+    m_nTotalCount = Math.max (nTotalCount, 0);
+
+    // Determine the page size
+    final int nDefaultPageSize = SMPWebAppConfiguration.getPaginationPageSize ();
+    int nPageSize = aWPEC.params ().getAsInt (PARAM_PAGE_SIZE, nDefaultPageSize);
+    if (nPageSize < MIN_PAGE_SIZE || nPageSize > MAX_PAGE_SIZE)
+      nPageSize = nDefaultPageSize;
+    m_nPageSize = nPageSize;
+
+    // Determine the page index - avoid an empty page in case the underlying
+    // data changed in the meantime
+    final int nPageCount = getPageCount ();
+    int nPageIndex = aWPEC.params ().getAsInt (PARAM_PAGE_INDEX, 0);
+    if (nPageIndex < 0)
+      nPageIndex = 0;
+    else
+      if (nPageIndex >= nPageCount)
+        nPageIndex = nPageCount - 1;
+    m_nPageIndex = nPageIndex;
+  }
+
+  /**
+   * @return The total number of items. Always &ge; 0.
+   */
+  @Nonnegative
+  public final long getTotalCount ()
+  {
+    return m_nTotalCount;
+  }
+
+  /**
+   * @return The number of items per page. Always &gt; 0.
+   */
+  @Nonnegative
+  public final int getPageSize ()
+  {
+    return m_nPageSize;
+  }
+
+  /**
+   * @return The 0-based index of the current page. Always &ge; 0.
+   */
+  @Nonnegative
+  public final int getPageIndex ()
+  {
+    return m_nPageIndex;
+  }
+
+  /**
+   * @return The total number of pages. Always &ge; 1.
+   */
+  @Nonnegative
+  public final int getPageCount ()
+  {
+    if (m_nTotalCount <= 0)
+      return 1;
+    return (int) Math.min ((m_nTotalCount + m_nPageSize - 1) / m_nPageSize, Integer.MAX_VALUE);
+  }
+
+  /**
+   * @return The 0-based index of the first item to be shown on the current page. Always &ge; 0.
+   */
+  @Nonnegative
+  public final int getFirstItemIndex ()
+  {
+    return m_nPageIndex * m_nPageSize;
+  }
+
+  @NonNull
+  private ISimpleURL _getPageURL (@Nonnegative final int nPageIndex, @Nonnegative final int nPageSize)
+  {
+    return new SimpleURL (m_aBaseURL).add (PARAM_PAGE_INDEX, nPageIndex).add (PARAM_PAGE_SIZE, nPageSize);
+  }
+
+  @NonNull
+  private HCLI _createItem (@NonNull final HCUL aUL,
+                            @NonNull final String sText,
+                            @Nullable final ISimpleURL aTargetURL,
+                            final boolean bActive)
+  {
+    final HCLI aLI = aUL.addAndReturnItem ((IHCNode) null).addClass (CSS_CLASS_PAGE_ITEM);
+    if (bActive)
+      aLI.addClass (CSS_CLASS_ACTIVE);
+    if (aTargetURL == null)
+    {
+      aLI.addClass (CSS_CLASS_DISABLED);
+      aLI.addChild (new HCSpan ().addClass (CSS_CLASS_PAGE_LINK).addChild (sText));
+    }
+    else
+      aLI.addChild (new HCA (aTargetURL).addClass (CSS_CLASS_PAGE_LINK).addChild (sText));
+    return aLI;
+  }
+
+  /**
+   * Align the provided DataTables with the server side pagination: the client side page length is
+   * set to the server side page size, so that the client side pagination never kicks in, and the
+   * client side page length selection is hidden, because the server side one is used instead.
+   *
+   * @param aDataTables
+   *        The DataTables to be modified. May not be <code>null</code>.
+   * @return The provided DataTables for chaining. Never <code>null</code>.
+   */
+  @NonNull
+  public DataTables applyTo (@NonNull final DataTables aDataTables)
+  {
+    ValueEnforcer.notNull (aDataTables, "DataTables");
+    return aDataTables.setPageLength (m_nPageSize).setLengthChange (false);
+  }
+
+  /**
+   * Create the UI of the pagination. If all items fit onto a single page, only the item count is
+   * shown.
+   *
+   * @return The created UI node. Never <code>null</code>.
+   */
+  @NonNull
+  public IHCNode getUI ()
+  {
+    final HCNodeList ret = new HCNodeList ();
+    final int nPageCount = getPageCount ();
+
+    // Textual information on the currently shown items
+    {
+      final String sInfo;
+      if (m_nTotalCount == 0)
+        sInfo = "No entry found";
+      else
+      {
+        final long nFirst = getFirstItemIndex () + 1L;
+        final long nLast = Math.min (nFirst + m_nPageSize - 1L, m_nTotalCount);
+        sInfo = "Showing entries " + nFirst + " to " + nLast + " of " + m_nTotalCount;
+      }
+      ret.addChild (new HCSpan ().addClass (DefaultCSSClassProvider.create ("me-3")).addChild (sInfo));
+    }
+
+    // The page size selector
+    {
+      final HCNodeList aPageSizes = new HCNodeList ();
+      aPageSizes.addChild (new HCTextNode ("Entries per page: "));
+      boolean bFirst = true;
+      for (final int nPageSize : PAGE_SIZES)
+      {
+        if (bFirst)
+          bFirst = false;
+        else
+          aPageSizes.addChild (new HCTextNode (" | "));
+
+        final String sText = Integer.toString (nPageSize);
+        if (nPageSize == m_nPageSize)
+          aPageSizes.addChild (new HCSpan ().addChild (sText));
+        else
+        {
+          // Start with the first page again, because the offsets change
+          aPageSizes.addChild (new HCA (_getPageURL (0, nPageSize)).addChild (sText));
+        }
+      }
+      ret.addChild (aPageSizes);
+    }
+
+    if (nPageCount > 1)
+    {
+      final HCUL aUL = new HCUL ().addClass (CSS_CLASS_PAGINATION);
+
+      // Previous page
+      _createItem (aUL, "«", m_nPageIndex > 0 ? _getPageURL (m_nPageIndex - 1, m_nPageSize) : null, false);
+
+      // Show at most 9 page links around the current page
+      final int nMaxLinks = 9;
+      int nFirstPage = Math.max (m_nPageIndex - nMaxLinks / 2, 0);
+      final int nLastPage = Math.min (nFirstPage + nMaxLinks - 1, nPageCount - 1);
+      nFirstPage = Math.max (nLastPage - nMaxLinks + 1, 0);
+
+      if (nFirstPage > 0)
+        _createItem (aUL, "1", _getPageURL (0, m_nPageSize), false);
+      if (nFirstPage > 1)
+        _createItem (aUL, "…", null, false);
+
+      for (int i = nFirstPage; i <= nLastPage; ++i)
+        _createItem (aUL, Integer.toString (i + 1), _getPageURL (i, m_nPageSize), i == m_nPageIndex);
+
+      if (nLastPage < nPageCount - 2)
+        _createItem (aUL, "…", null, false);
+      if (nLastPage < nPageCount - 1)
+        _createItem (aUL, Integer.toString (nPageCount), _getPageURL (nPageCount - 1, m_nPageSize), false);
+
+      // Next page
+      _createItem (aUL,
+                   "»",
+                   m_nPageIndex < nPageCount - 1 ? _getPageURL (m_nPageIndex + 1, m_nPageSize) : null,
+                   false);
+
+      ret.addChild (new HCNav ().addChild (aUL));
+    }
+    return ret;
+  }
+}

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/pub/PagePublicStart.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/pub/PagePublicStart.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import com.helger.annotation.Nonempty;
 import com.helger.base.compare.ESortOrder;
+import com.helger.base.string.StringHelper;
 import com.helger.collection.commons.ICommonsList;
 import com.helger.html.hc.html.tabular.AbstractHCTable;
 import com.helger.html.hc.html.tabular.HCRow;
@@ -91,9 +92,13 @@ public final class PagePublicStart extends AbstractSMPWebPage
       final ISMPServiceGroupManager aSMPServiceGroupMgr = SMPMetaManager.getServiceGroupMgr ();
       try
       {
-        // Server side pagination - only query the entries of the current page
-        final SMPPagination aPagination = new SMPPagination (aWPEC, aSMPServiceGroupMgr.getSMPServiceGroupCount ());
-        final ICommonsList <ISMPServiceGroup> aServiceGroups = aSMPServiceGroupMgr.getAllSMPServiceGroups (aPagination.getFirstItemIndex (),
+        // Server side pagination and filtering - only query the entries of the
+        // current page
+        final String sSearchText = SMPPagination.getSearchText (aWPEC);
+        final SMPPagination aPagination = new SMPPagination (aWPEC,
+                                                             aSMPServiceGroupMgr.getSMPServiceGroupCount (sSearchText));
+        final ICommonsList <ISMPServiceGroup> aServiceGroups = aSMPServiceGroupMgr.getAllSMPServiceGroups (sSearchText,
+                                                                                                           aPagination.getFirstItemIndex (),
                                                                                                            aPagination.getPageSize ());
 
         // Use dynamic or static table?
@@ -152,6 +157,7 @@ public final class PagePublicStart extends AbstractSMPWebPage
                                                                                                                      .setTargetBlank ()
                                                                                                                      .addChild (EFontAwesome6Icon.UP_RIGHT_FROM_SQUARE.getAsNode ()));
         }
+        aNodeList.addChild (aPagination.getUI ());
         if (aFinalTable.hasBodyRows ())
         {
           aNodeList.addChild (aFinalTable);
@@ -162,10 +168,10 @@ public final class PagePublicStart extends AbstractSMPWebPage
             aPagination.applyTo (aDataTables);
             aNodeList.addChild (aDataTables);
           }
-          aNodeList.addChild (aPagination.getUI ());
         }
         else
-          aNodeList.addChild (info ("This SMP does not manage any participant yet."));
+          aNodeList.addChild (info (StringHelper.isNotEmpty (sSearchText) ? "No participant matches the search criteria."
+                                                                          : "This SMP does not manage any participant yet."));
       }
       catch (final RuntimeException ex)
       {

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/pub/PagePublicStart.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/pub/PagePublicStart.java
@@ -39,6 +39,7 @@ import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroupManager;
 import com.helger.phoss.smp.rest.SMPRestDataProvider;
 import com.helger.phoss.smp.ui.AbstractSMPWebPage;
 import com.helger.phoss.smp.ui.SMPExtensionUI;
+import com.helger.phoss.smp.ui.SMPPagination;
 import com.helger.photon.bootstrap5.table.BootstrapTable;
 import com.helger.photon.bootstrap5.uictrls.datatables.BootstrapDTColAction;
 import com.helger.photon.bootstrap5.uictrls.datatables.BootstrapDataTables;
@@ -90,7 +91,10 @@ public final class PagePublicStart extends AbstractSMPWebPage
       final ISMPServiceGroupManager aSMPServiceGroupMgr = SMPMetaManager.getServiceGroupMgr ();
       try
       {
-        final ICommonsList <ISMPServiceGroup> aServiceGroups = aSMPServiceGroupMgr.getAllSMPServiceGroups ();
+        // Server side pagination - only query the entries of the current page
+        final SMPPagination aPagination = new SMPPagination (aWPEC, aSMPServiceGroupMgr.getSMPServiceGroupCount ());
+        final ICommonsList <ISMPServiceGroup> aServiceGroups = aSMPServiceGroupMgr.getAllSMPServiceGroups (aPagination.getFirstItemIndex (),
+                                                                                                           aPagination.getPageSize ());
 
         // Use dynamic or static table?
         final boolean bUseDataTables = SMPWebAppConfiguration.isStartPageDynamicTable ();
@@ -155,8 +159,10 @@ public final class PagePublicStart extends AbstractSMPWebPage
           if (bUseDataTables)
           {
             final BootstrapDataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aFinalTable);
+            aPagination.applyTo (aDataTables);
             aNodeList.addChild (aDataTables);
           }
+          aNodeList.addChild (aPagination.getUI ());
         }
         else
           aNodeList.addChild (info ("This SMP does not manage any participant yet."));

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureBusinessCard.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureBusinessCard.java
@@ -1250,10 +1250,13 @@ public final class PageSecureBusinessCard extends AbstractSMPWebPageForm <ISMPBu
     final HCNodeList aNodeList = aWPEC.getNodeList ();
     final String sDirectoryName = SMPWebAppConfiguration.getDirectoryName ();
     final ISMPBusinessCardManager aBusinessCardMgr = SMPMetaManager.getBusinessCardMgr ();
-    // Server side pagination - only query the entries of the current page
+    // Server side pagination and filtering - only query the entries of the
+    // current page
     final long nTotalBusinessCardCount = aBusinessCardMgr.getSMPBusinessCardCount ();
-    final SMPPagination aPagination = new SMPPagination (aWPEC, nTotalBusinessCardCount);
-    final ICommonsList <ISMPBusinessCard> aAllBusinessCards = aBusinessCardMgr.getAllSMPBusinessCards (aPagination.getFirstItemIndex (),
+    final String sSearchText = SMPPagination.getSearchText (aWPEC);
+    final SMPPagination aPagination = new SMPPagination (aWPEC, aBusinessCardMgr.getSMPBusinessCardCount (sSearchText));
+    final ICommonsList <ISMPBusinessCard> aAllBusinessCards = aBusinessCardMgr.getAllSMPBusinessCards (sSearchText,
+                                                                                                       aPagination.getFirstItemIndex (),
                                                                                                        aPagination.getPageSize ());
 
     EFontAwesome6Icon.registerResourcesForThisRequest ();
@@ -1338,6 +1341,6 @@ public final class PageSecureBusinessCard extends AbstractSMPWebPageForm <ISMPBu
 
     final DataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aTable);
     aPagination.applyTo (aDataTables);
-    aNodeList.addChild (aTable).addChild (aDataTables).addChild (aPagination.getUI ());
+    aNodeList.addChild (aPagination.getUI ()).addChild (aTable).addChild (aDataTables);
   }
 }

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureBusinessCard.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureBusinessCard.java
@@ -79,6 +79,7 @@ import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroupManager;
 import com.helger.phoss.smp.settings.ISMPSettings;
 import com.helger.phoss.smp.ui.AbstractSMPWebPageForm;
 import com.helger.phoss.smp.ui.SMPCommonUI;
+import com.helger.phoss.smp.ui.SMPPagination;
 import com.helger.phoss.smp.ui.ajax.CAjax;
 import com.helger.phoss.smp.ui.secure.hc.HCServiceGroupSelect;
 import com.helger.photon.ajax.decl.IAjaxFunctionDeclaration;
@@ -1249,7 +1250,11 @@ public final class PageSecureBusinessCard extends AbstractSMPWebPageForm <ISMPBu
     final HCNodeList aNodeList = aWPEC.getNodeList ();
     final String sDirectoryName = SMPWebAppConfiguration.getDirectoryName ();
     final ISMPBusinessCardManager aBusinessCardMgr = SMPMetaManager.getBusinessCardMgr ();
-    final ICommonsList <ISMPBusinessCard> aAllBusinessCards = aBusinessCardMgr.getAllSMPBusinessCards ();
+    // Server side pagination - only query the entries of the current page
+    final long nTotalBusinessCardCount = aBusinessCardMgr.getSMPBusinessCardCount ();
+    final SMPPagination aPagination = new SMPPagination (aWPEC, nTotalBusinessCardCount);
+    final ICommonsList <ISMPBusinessCard> aAllBusinessCards = aBusinessCardMgr.getAllSMPBusinessCards (aPagination.getFirstItemIndex (),
+                                                                                                       aPagination.getPageSize ());
 
     EFontAwesome6Icon.registerResourcesForThisRequest ();
 
@@ -1262,7 +1267,7 @@ public final class PageSecureBusinessCard extends AbstractSMPWebPageForm <ISMPBu
                                                                        ACTION_PUBLISH_ALL_TO_INDEXER))
                                                .setIcon (EFontAwesome6Icon.ARROW_ROTATE_RIGHT)
                                                .addChild ("Update all Business Cards in " + sDirectoryName)
-                                               .setDisabled (aAllBusinessCards.isEmpty ()));
+                                               .setDisabled (nTotalBusinessCardCount <= 0));
 
       aNodeList.addChild (aToolbar);
 
@@ -1332,6 +1337,7 @@ public final class PageSecureBusinessCard extends AbstractSMPWebPageForm <ISMPBu
     }
 
     final DataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aTable);
-    aNodeList.addChild (aTable).addChild (aDataTables);
+    aPagination.applyTo (aDataTables);
+    aNodeList.addChild (aTable).addChild (aDataTables).addChild (aPagination.getUI ());
   }
 }

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureEndpointList.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureEndpointList.java
@@ -76,9 +76,13 @@ public final class PageSecureEndpointList extends AbstractPageSecureEndpoint
     final HCNodeList aNodeList = aWPEC.getNodeList ();
     final ISMPServiceInformationManager aServiceInfoMgr = SMPMetaManager.getServiceInformationMgr ();
 
-    // Server side pagination - only query the entries of the current page
-    final SMPPagination aPagination = new SMPPagination (aWPEC, aServiceInfoMgr.getSMPServiceInformationCount ());
-    final ICommonsList <ISMPServiceInformation> aAllServiceInfos = aServiceInfoMgr.getAllSMPServiceInformation (aPagination.getFirstItemIndex (),
+    // Server side pagination and filtering - only query the entries of the
+    // current page
+    final String sSearchText = SMPPagination.getSearchText (aWPEC);
+    final SMPPagination aPagination = new SMPPagination (aWPEC,
+                                                         aServiceInfoMgr.getSMPServiceInformationCount (sSearchText));
+    final ICommonsList <ISMPServiceInformation> aAllServiceInfos = aServiceInfoMgr.getAllSMPServiceInformation (sSearchText,
+                                                                                                                aPagination.getFirstItemIndex (),
                                                                                                                 aPagination.getPageSize ());
 
     EFontAwesome6Icon.registerResourcesForThisRequest ();
@@ -155,6 +159,6 @@ public final class PageSecureEndpointList extends AbstractPageSecureEndpoint
 
     final DataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aTable);
     aPagination.applyTo (aDataTables);
-    aNodeList.addChild (aTable).addChild (aDataTables).addChild (aPagination.getUI ());
+    aNodeList.addChild (aPagination.getUI ()).addChild (aTable).addChild (aDataTables);
   }
 }

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureEndpointList.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureEndpointList.java
@@ -22,9 +22,7 @@ import org.jspecify.annotations.NonNull;
 
 import com.helger.annotation.Nonempty;
 import com.helger.base.compare.ESortOrder;
-import com.helger.collection.commons.CommonsHashSet;
 import com.helger.collection.commons.ICommonsList;
-import com.helger.collection.commons.ICommonsSet;
 import com.helger.html.hc.html.tabular.HCRow;
 import com.helger.html.hc.html.tabular.HCTable;
 import com.helger.html.hc.html.textlevel.HCA;
@@ -42,6 +40,7 @@ import com.helger.phoss.smp.domain.serviceinfo.ISMPServiceInformationManager;
 import com.helger.phoss.smp.domain.serviceinfo.SMPEndpointHelper;
 import com.helger.phoss.smp.nicename.SMPNiceNameUI;
 import com.helger.phoss.smp.rest.SMPRestDataProvider;
+import com.helger.phoss.smp.ui.SMPPagination;
 import com.helger.phoss.smp.ui.cache.SMPTransportProfileCache;
 import com.helger.photon.bootstrap5.buttongroup.BootstrapButtonToolbar;
 import com.helger.photon.bootstrap5.uictrls.datatables.BootstrapDTColAction;
@@ -77,14 +76,14 @@ public final class PageSecureEndpointList extends AbstractPageSecureEndpoint
     final HCNodeList aNodeList = aWPEC.getNodeList ();
     final ISMPServiceInformationManager aServiceInfoMgr = SMPMetaManager.getServiceInformationMgr ();
 
-    final ICommonsList <ISMPServiceInformation> aAllServiceInfos = aServiceInfoMgr.getAllSMPServiceInformation ();
+    // Server side pagination - only query the entries of the current page
+    final SMPPagination aPagination = new SMPPagination (aWPEC, aServiceInfoMgr.getSMPServiceInformationCount ());
+    final ICommonsList <ISMPServiceInformation> aAllServiceInfos = aServiceInfoMgr.getAllSMPServiceInformation (aPagination.getFirstItemIndex (),
+                                                                                                                aPagination.getPageSize ());
 
     EFontAwesome6Icon.registerResourcesForThisRequest ();
 
-    // Count unique service groups
-    final ICommonsSet <String> aServiceGroupIDs = new CommonsHashSet <> ();
-    aAllServiceInfos.findAllMapped (ISMPServiceInformation::getServiceGroupID, aServiceGroupIDs::add);
-    final boolean bHideDetails = aServiceGroupIDs.size () > 1000;
+    final boolean bHideDetails = SMPMetaManager.getServiceGroupMgr ().getSMPServiceGroupCount () > 1000;
 
     final BootstrapButtonToolbar aToolbar = new BootstrapButtonToolbar (aWPEC);
     aToolbar.addButton ("Create new Endpoint", createCreateURL (aWPEC), EDefaultIcon.NEW);
@@ -155,6 +154,7 @@ public final class PageSecureEndpointList extends AbstractPageSecureEndpoint
     }
 
     final DataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aTable);
-    aNodeList.addChild (aTable).addChild (aDataTables);
+    aPagination.applyTo (aDataTables);
+    aNodeList.addChild (aTable).addChild (aDataTables).addChild (aPagination.getUI ());
   }
 }

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureRedirect.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureRedirect.java
@@ -27,6 +27,7 @@ import com.helger.base.state.EValidity;
 import com.helger.base.state.IValidityIndicator;
 import com.helger.base.string.StringHelper;
 import com.helger.base.url.URLHelper;
+import com.helger.collection.commons.ICommonsList;
 import com.helger.html.hc.html.HC_Target;
 import com.helger.html.hc.html.forms.HCEdit;
 import com.helger.html.hc.html.forms.HCHiddenField;
@@ -51,6 +52,7 @@ import com.helger.phoss.smp.domain.serviceinfo.ISMPServiceInformationManager;
 import com.helger.phoss.smp.rest.SMPRestFilter;
 import com.helger.phoss.smp.ui.AbstractSMPWebPageForm;
 import com.helger.phoss.smp.ui.SMPExtensionUI;
+import com.helger.phoss.smp.ui.SMPPagination;
 import com.helger.phoss.smp.ui.secure.hc.HCServiceGroupSelect;
 import com.helger.photon.app.url.LinkHelper;
 import com.helger.photon.bootstrap5.button.BootstrapButton;
@@ -418,6 +420,14 @@ public final class PageSecureRedirect extends AbstractSMPWebPageForm <ISMPRedire
     final HCNodeList aNodeList = aWPEC.getNodeList ();
     final ISMPRedirectManager aRedirectMgr = SMPMetaManager.getRedirectMgr ();
 
+    // Server side pagination and filtering - only query the entries of the
+    // current page
+    final String sSearchText = SMPPagination.getSearchText (aWPEC);
+    final SMPPagination aPagination = new SMPPagination (aWPEC, aRedirectMgr.getSMPRedirectCount (sSearchText));
+    final ICommonsList <ISMPRedirect> aAllRedirects = aRedirectMgr.getAllSMPRedirects (sSearchText,
+                                                                                       aPagination.getFirstItemIndex (),
+                                                                                       aPagination.getPageSize ());
+
     EFontAwesome6Icon.registerResourcesForThisRequest ();
 
     final BootstrapButtonToolbar aToolbar = new BootstrapButtonToolbar (aWPEC);
@@ -429,7 +439,7 @@ public final class PageSecureRedirect extends AbstractSMPWebPageForm <ISMPRedire
                                         new DTCol ("Document type ID").setDataSort (1, 0),
                                         new DTCol ("Target URL"),
                                         new BootstrapDTColAction (aDisplayLocale)).setID (getID ());
-    for (final ISMPRedirect aCurObject : aRedirectMgr.getAllSMPRedirects ())
+    for (final ISMPRedirect aCurObject : aAllRedirects)
     {
       final StringMap aParams = new StringMap ();
       aParams.putIn (FIELD_SERVICE_GROUP_ID, aCurObject.getServiceGroupID ());
@@ -465,7 +475,8 @@ public final class PageSecureRedirect extends AbstractSMPWebPageForm <ISMPRedire
     }
 
     final DataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aTable);
+    aPagination.applyTo (aDataTables);
 
-    aNodeList.addChild (aTable).addChild (aDataTables);
+    aNodeList.addChild (aPagination.getUI ()).addChild (aTable).addChild (aDataTables);
   }
 }

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureServiceGroup.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureServiceGroup.java
@@ -948,10 +948,14 @@ public final class PageSecureServiceGroup extends AbstractSMPWebPageForm <ISMPSe
 
     try
     {
-      // Server side pagination - only query the entries of the current page
+      // Server side pagination and filtering - only query the entries of the
+      // current page
       final long nTotalServiceGroupCount = aServiceGroupMgr.getSMPServiceGroupCount ();
-      final SMPPagination aPagination = new SMPPagination (aWPEC, nTotalServiceGroupCount);
-      final ICommonsList <ISMPServiceGroup> aAllServiceGroups = aServiceGroupMgr.getAllSMPServiceGroups (aPagination.getFirstItemIndex (),
+      final String sSearchText = SMPPagination.getSearchText (aWPEC);
+      final SMPPagination aPagination = new SMPPagination (aWPEC,
+                                                           aServiceGroupMgr.getSMPServiceGroupCount (sSearchText));
+      final ICommonsList <ISMPServiceGroup> aAllServiceGroups = aServiceGroupMgr.getAllSMPServiceGroups (sSearchText,
+                                                                                                         aPagination.getFirstItemIndex (),
                                                                                                          aPagination.getPageSize ());
 
       final BootstrapButtonToolbar aToolbar = new BootstrapButtonToolbar (aWPEC);
@@ -1064,7 +1068,7 @@ public final class PageSecureServiceGroup extends AbstractSMPWebPageForm <ISMPSe
 
       final DataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aTable);
       aPagination.applyTo (aDataTables);
-      aNodeList.addChild (aTable).addChild (aDataTables).addChild (aPagination.getUI ());
+      aNodeList.addChild (aPagination.getUI ()).addChild (aTable).addChild (aDataTables);
     }
     catch (final RuntimeException ex)
     {

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureServiceGroup.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ui/secure/PageSecureServiceGroup.java
@@ -78,6 +78,7 @@ import com.helger.phoss.smp.smlhook.RegistrationHookFactory;
 import com.helger.phoss.smp.ui.AbstractSMPWebPageForm;
 import com.helger.phoss.smp.ui.SMPCommonUI;
 import com.helger.phoss.smp.ui.SMPExtensionUI;
+import com.helger.phoss.smp.ui.SMPPagination;
 import com.helger.phoss.smp.ui.ajax.CAjax;
 import com.helger.phoss.smp.ui.cache.SMPOwnerNameCache;
 import com.helger.phoss.smp.ui.secure.hc.HCSMPCustomPropertyTypeSelect;
@@ -947,7 +948,11 @@ public final class PageSecureServiceGroup extends AbstractSMPWebPageForm <ISMPSe
 
     try
     {
-      final ICommonsList <ISMPServiceGroup> aAllServiceGroups = aServiceGroupMgr.getAllSMPServiceGroups ();
+      // Server side pagination - only query the entries of the current page
+      final long nTotalServiceGroupCount = aServiceGroupMgr.getSMPServiceGroupCount ();
+      final SMPPagination aPagination = new SMPPagination (aWPEC, nTotalServiceGroupCount);
+      final ICommonsList <ISMPServiceGroup> aAllServiceGroups = aServiceGroupMgr.getAllSMPServiceGroups (aPagination.getFirstItemIndex (),
+                                                                                                         aPagination.getPageSize ());
 
       final BootstrapButtonToolbar aToolbar = new BootstrapButtonToolbar (aWPEC);
       aToolbar.addButton ("Create new Service group", createCreateURL (aWPEC), EDefaultIcon.NEW);
@@ -956,18 +961,18 @@ public final class PageSecureServiceGroup extends AbstractSMPWebPageForm <ISMPSe
       {
         // Disable button if no SML URL is configured
         // Disable button if no service group is present
-        final boolean bTooMany = aAllServiceGroups.size () > 10_000;
+        final boolean bTooMany = nTotalServiceGroupCount > 10_000;
         aToolbar.addAndReturnButton ("Check DNS state" + (bTooMany ? " (too many entries)" : ""),
                                      aWPEC.getSelfHref ().add (CPageParam.PARAM_ACTION, ACTION_CHECK_DNS),
                                      EDefaultIcon.MAGNIFIER)
                 .setDisabled (aSettings.getSMLDNSZone () == null ||
-                  aAllServiceGroups.isEmpty () ||
+                  nTotalServiceGroupCount <= 0 ||
                   bTooMany ||
                   !aSettings.isSMLEnabled ());
       }
       aNodeList.addChild (aToolbar);
 
-      final boolean bShowDetails = aAllServiceGroups.size () <= 1_000;
+      final boolean bShowDetails = nTotalServiceGroupCount <= 1_000;
 
       final HCTable aTable = new HCTable (new DTCol ("Participant ID").setInitialSorting (ESortOrder.ASCENDING),
                                           new DTCol ("Owner"),
@@ -1058,7 +1063,8 @@ public final class PageSecureServiceGroup extends AbstractSMPWebPageForm <ISMPSe
       }
 
       final DataTables aDataTables = BootstrapDataTables.createDefaultDataTables (aWPEC, aTable);
-      aNodeList.addChild (aTable).addChild (aDataTables);
+      aPagination.applyTo (aDataTables);
+      aNodeList.addChild (aTable).addChild (aDataTables).addChild (aPagination.getUI ());
     }
     catch (final RuntimeException ex)
     {


### PR DESCRIPTION
Added server side pagination and search for public list of participants and secure list of service groups, list of endpoint, list of redirects and list of business cards so the UI is responsive even in large data (tens of thousands of records).

Relates to #525 

How it looks:

<img width="3498" height="1545" alt="image" src="https://github.com/user-attachments/assets/cb243815-4ae8-4643-b35b-d99706fe3125" />

<img width="2737" height="1058" alt="image" src="https://github.com/user-attachments/assets/99e33292-ddb6-4815-bf52-0a92d11f21a0" />

<img width="1542" height="1613" alt="image" src="https://github.com/user-attachments/assets/ea2e11cb-530d-4ba9-aa31-d7e17c9fb2bc" />

<img width="1479" height="893" alt="image" src="https://github.com/user-attachments/assets/531b0bf9-8eb8-4a27-8c79-83608e0b09df" />

