### PR TITLE
Fix X-Forwarded host port handling

### DIFF
--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestDataProvider.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestDataProvider.java
@@ -147,13 +147,33 @@ public class SMPRestDataProvider implements ISMPServerAPIDataProvider
 
     // Host
     String sHost = m_aRequestScope.headers ().getFirstHeaderValue (HTTP_X_FORWARDED_HOST);
+    int nHostPort = -1;
     if (StringHelper.isNotEmpty (sHost))
+    {
       bFallbackToLocalPort = false;
+      // Host may contain a port number as well. Separate it to avoid appending the
+      // X-Forwarded-Port value to a host that already contains the same port.
+      // Consider IPv6 addresses like "[::1]" or "[::1]:8080" - the port separator must be
+      // after the closing bracket.
+      final int nBracketEnd = sHost.lastIndexOf (']');
+      final int nPortSep = sHost.lastIndexOf (':');
+      if (nPortSep > 0 && nPortSep > nBracketEnd)
+      {
+        final int nParsedPort = StringParser.parseInt (sHost.substring (nPortSep + 1), -1);
+        if (nParsedPort >= 0)
+        {
+          sHost = sHost.substring (0, nPortSep);
+          nHostPort = nParsedPort;
+        }
+      }
+    }
     else
       sHost = aHttpRequest.getServerName ();
 
     // Port
     int nPort = StringParser.parseInt (m_aRequestScope.headers ().getFirstHeaderValue (HTTP_X_FORWARDED_PORT), -1);
+    if (nPort < 0)
+      nPort = nHostPort;
     // If no fallback to local port should be performed, the default port of the selected scheme
     // is used
     if (nPort < 0 && bFallbackToLocalPort)

--- a/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/rest/SMPRestDataProviderTest.java
+++ b/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/rest/SMPRestDataProviderTest.java
@@ -78,12 +78,27 @@ public final class SMPRestDataProviderTest
   @NonNull
   private static SMPRestDataProvider _createDataProvider (@Nullable final String sForwardedHeaderValue)
   {
+    return _createDataProvider (sForwardedHeaderValue, null, null, null);
+  }
+
+  @NonNull
+  private static SMPRestDataProvider _createDataProvider (@Nullable final String sForwardedHeaderValue,
+                                                          @Nullable final String sXForwardedProto,
+                                                          @Nullable final String sXForwardedHost,
+                                                          @Nullable final String sXForwardedPort)
+  {
     final MockHttpServletRequest aHttpRequest = new MockHttpServletRequest ();
     aHttpRequest.setAllPaths (REQUEST_URL);
     // No servlet context is present, so the context path must be set explicitly
     aHttpRequest.setContextPath (CONTEXT_PATH);
     if (sForwardedHeaderValue != null)
       aHttpRequest.addHeader ("Forwarded", sForwardedHeaderValue);
+    if (sXForwardedProto != null)
+      aHttpRequest.addHeader ("X-Forwarded-Proto", sXForwardedProto);
+    if (sXForwardedHost != null)
+      aHttpRequest.addHeader ("X-Forwarded-Host", sXForwardedHost);
+    if (sXForwardedPort != null)
+      aHttpRequest.addHeader ("X-Forwarded-Port", sXForwardedPort);
 
     final IRequestWebScopeWithoutResponse aRequestScope = new RequestWebScope (aHttpRequest,
                                                                               new MockHttpServletResponse ());
@@ -160,6 +175,38 @@ public final class SMPRestDataProviderTest
                   aDP.getCurrentURI ().toString ());
     assertEquals ("http://internal.host:90" + CONTEXT_PATH,
                   aDP.getBaseUriBuilder ());
+  }
+
+  @Test
+  public void testXForwardedHostContainingPort ()
+  {
+    _setPublicURLMode ("x-forwarded-header");
+
+    final SMPRestDataProvider aDP = _createDataProvider (null, "https", "example.com:8443", "8443");
+    assertEquals ("https://example.com:8443" + CONTEXT_PATH + "/iso6523-actorid-upis%3A%3A9915%3Atest",
+                  aDP.getCurrentURI ().toString ());
+    assertEquals ("https://example.com:8443" + CONTEXT_PATH,
+                  aDP.getBaseUriBuilder ());
+  }
+
+  @Test
+  public void testXForwardedHostContainingPortWithoutSeparatePort ()
+  {
+    _setPublicURLMode ("x-forwarded-header");
+
+    final SMPRestDataProvider aDP = _createDataProvider (null, "https", "example.com:8443", null);
+    assertEquals ("https://example.com:8443" + CONTEXT_PATH + "/iso6523-actorid-upis%3A%3A9915%3Atest",
+                  aDP.getCurrentURI ().toString ());
+  }
+
+  @Test
+  public void testXForwardedHostIPv6ContainingPort ()
+  {
+    _setPublicURLMode ("x-forwarded-header");
+
+    final SMPRestDataProvider aDP = _createDataProvider (null, "https", "[2001:db8::1]:8443", "8443");
+    assertEquals ("https://[2001:db8::1]:8443" + CONTEXT_PATH + "/iso6523-actorid-upis%3A%3A9915%3Atest",
+                  aDP.getCurrentURI ().toString ());
   }
 
   @Test


### PR DESCRIPTION
## Problem

When `X-Forwarded-Host` already contains a port and `X-Forwarded-Port` is also supplied, the generated public URL contains the port twice, for example `https://example.com:8443:8443/...`.

## Changes

- Separate an optional port from `X-Forwarded-Host` before URL construction.
- Prefer the dedicated `X-Forwarded-Port` value and otherwise preserve the port embedded in the host.
- Add regression coverage for hostname and bracketed IPv6 values, including the case without a separate port header.

## Verification

- `mvn -pl phoss-smp-webapp -Dtest=SMPRestDataProviderTest test`
- `mvn clean verify` (all 9 reactor modules passed)