### PR TITLE
Fix MongoDB no-op security updates

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/security/AbstractBusinessObjectManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/security/AbstractBusinessObjectManagerMongoDB.java
@@ -103,7 +103,24 @@ public abstract class AbstractBusinessObjectManagerMongoDB <TINT extends IHasID 
     if (StringHelper.isEmpty (sID))
       return EChange.UNCHANGED;
 
-    final UpdateResult aUpdateResult = getCollection ().updateOne (whereID (sID), aUpdate);
+    return genericUpdateOne (whereID (sID), aUpdate);
+  }
+
+  @NonNull
+  protected EChange genericUpdateOne (@Nullable final String sID,
+                                      @NonNull final Bson aAdditionalFilter,
+                                      @NonNull final Bson aUpdate)
+  {
+    if (StringHelper.isEmpty (sID))
+      return EChange.UNCHANGED;
+
+    return genericUpdateOne (Filters.and (whereID (sID), aAdditionalFilter), aUpdate);
+  }
+
+  @NonNull
+  private EChange genericUpdateOne (@NonNull final Bson aFilter, @NonNull final Bson aUpdate)
+  {
+    final UpdateResult aUpdateResult = getCollection ().updateOne (aFilter, aUpdate);
 
     // Was an element changed?
     if (aUpdateResult.getModifiedCount () == 0)
@@ -116,6 +133,7 @@ public abstract class AbstractBusinessObjectManagerMongoDB <TINT extends IHasID 
   public EChange deleteEntity (@Nullable final String sID)
   {
     return genericUpdateOne (sID,
+                             Filters.eq (BSON_DELETED_TIME, null),
                              Updates.combine (Updates.set (BSON_DELETED_TIME,
                                                            asBsonDate (PDTFactory.getCurrentLocalDateTime ())),
                                               Updates.set (BSON_DELETED_USER_ID,
@@ -126,6 +144,7 @@ public abstract class AbstractBusinessObjectManagerMongoDB <TINT extends IHasID 
   public EChange undeleteEntity (@Nullable final String sID)
   {
     return genericUpdateOne (sID,
+                             Filters.ne (BSON_DELETED_TIME, null),
                              Updates.combine (Updates.set (BSON_DELETED_TIME, null),
                                               Updates.set (BSON_DELETED_USER_ID, null)));
   }

--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/security/UserGroupManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/security/UserGroupManagerMongoDB.java
@@ -310,6 +310,7 @@ public class UserGroupManagerMongoDB extends AbstractBusinessObjectManagerMongoD
       return EChange.UNCHANGED;
 
     final EChange eChange = genericUpdateOne (sUserGroupID,
+                                              Filters.ne (BSON_USER_GROUP_USERS, sUserID),
                                               addLastModToUpdate (Updates.addToSet (BSON_USER_GROUP_USERS, sUserID)));
     if (eChange.isChanged ())
     {
@@ -332,6 +333,7 @@ public class UserGroupManagerMongoDB extends AbstractBusinessObjectManagerMongoD
       return EChange.UNCHANGED;
 
     final EChange eChange = genericUpdateOne (sUserGroupID,
+                                              Filters.eq (BSON_USER_GROUP_USERS, sUserID),
                                               addLastModToUpdate (Updates.pull (BSON_USER_GROUP_USERS, sUserID)));
     if (eChange.isChanged ())
     {
@@ -390,6 +392,7 @@ public class UserGroupManagerMongoDB extends AbstractBusinessObjectManagerMongoD
       return EChange.UNCHANGED;
 
     final EChange eChange = genericUpdateOne (sUserGroupID,
+                                              Filters.ne (BSON_USER_GROUP_ROLES, sRoleID),
                                               addLastModToUpdate (Updates.addToSet (BSON_USER_GROUP_ROLES, sRoleID)));
     if (eChange.isChanged ())
     {
@@ -412,6 +415,7 @@ public class UserGroupManagerMongoDB extends AbstractBusinessObjectManagerMongoD
       return EChange.UNCHANGED;
 
     final EChange eChange = genericUpdateOne (sUserGroupID,
+                                              Filters.eq (BSON_USER_GROUP_ROLES, sRoleID),
                                               addLastModToUpdate (Updates.pull (BSON_USER_GROUP_ROLES, sRoleID)));
     if (eChange.isChanged ())
     {

--- a/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/security/UserGroupManagerMongoDBTest.java
+++ b/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/security/UserGroupManagerMongoDBTest.java
@@ -69,8 +69,7 @@ public final class UserGroupManagerMongoDBTest
       final String sUserID = GlobalIDFactory.getNewStringID ();
 
       assertTrue (aUserGroupMgr.assignUserToUserGroup (sUserGroup1ID, sUserID).isChanged ());
-      // Should be false but couldn't figure it out
-      assertTrue (aUserGroupMgr.assignUserToUserGroup (sUserGroup1ID, sUserID).isChanged ());
+      assertFalse (aUserGroupMgr.assignUserToUserGroup (sUserGroup1ID, sUserID).isChanged ());
       assertTrue (aUserGroupMgr.isUserAssignedToUserGroup (sUserGroup1ID, sUserID));
       assertFalse (aUserGroupMgr.isUserAssignedToUserGroup (sUserGroup1ID, "another uuid"));
 
@@ -86,6 +85,7 @@ public final class UserGroupManagerMongoDBTest
         assertTrue (allUserGroupIDsWithAssignedUser.contains (sUserGroup2ID));
 
         assertTrue (aUserGroupMgr.unassignUserFromUserGroup (sUserGroup1ID, sUserID).isChanged ());
+        assertFalse (aUserGroupMgr.unassignUserFromUserGroup (sUserGroup1ID, sUserID).isChanged ());
         assertFalse (aUserGroupMgr.isUserAssignedToUserGroup (sUserGroup1ID, sUserID));
         assertTrue (aUserGroupMgr.unassignUserFromAllUserGroups (sUserID).isChanged ());
         assertFalse (aUserGroupMgr.isUserAssignedToUserGroup (sUserGroup2ID, sUserID));
@@ -93,6 +93,7 @@ public final class UserGroupManagerMongoDBTest
         final String sRole1ID = GlobalIDFactory.getNewStringID ();
         final String sRole2ID = GlobalIDFactory.getNewStringID ();
         assertTrue (aUserGroupMgr.assignRoleToUserGroup (sUserGroup1ID, sRole1ID).isChanged ());
+        assertFalse (aUserGroupMgr.assignRoleToUserGroup (sUserGroup1ID, sRole1ID).isChanged ());
         assertTrue (aUserGroupMgr.assignRoleToUserGroup (sUserGroup1ID, sRole2ID).isChanged ());
         assertTrue (aUserGroupMgr.assignRoleToUserGroup (sUserGroup2ID, sRole1ID).isChanged ());
 
@@ -116,8 +117,7 @@ public final class UserGroupManagerMongoDBTest
         assertFalse (aUserGroupMgr.getAllDeletedUserGroups ().contains (aUserGroup2));
 
         assertTrue (aUserGroupMgr.deleteUserGroup (sUserGroup2ID).isChanged ());
-        // Should be false, but it's only an update operation
-        assertTrue (aUserGroupMgr.deleteUserGroup (sUserGroup2ID).isChanged ());
+        assertFalse (aUserGroupMgr.deleteUserGroup (sUserGroup2ID).isChanged ());
 
         assertTrue (aUserGroupMgr.getAll ().contains (aUserGroup1));
         assertTrue (aUserGroupMgr.getAll ().contains (aUserGroup2));
@@ -139,6 +139,7 @@ public final class UserGroupManagerMongoDBTest
         assertTrue (aUserGroupMgr.assignRoleToUserGroup (sUserGroup2ID, sRole1ID).isChanged ());
         assertTrue (aUserGroupMgr.containsUserGroupWithAssignedRole (sRole1ID));
         assertTrue (aUserGroupMgr.unassignRoleFromUserGroup (sUserGroup2ID, sRole1ID).isChanged ());
+        assertFalse (aUserGroupMgr.unassignRoleFromUserGroup (sUserGroup2ID, sRole1ID).isChanged ());
         assertFalse (aUserGroupMgr.containsUserGroupWithAssignedRole (sRole1ID));
       }
       finally


### PR DESCRIPTION
## Summary
- apply MongoDB security updates only when the requested state transition is needed
- avoid rewriting deletion metadata for repeated delete/undelete calls
- prevent duplicate user/role group assignments and unassignments from updating modification metadata or firing success callbacks
- update the MongoDB user-group test to assert `EChange.UNCHANGED` for these no-op operations

## Background
`addLastModToUpdate` always changes the last-modification fields. As a result, an otherwise no-op `$addToSet` or `$pull` still produced `modifiedCount == 1`, and repeated soft deletes also reported a change. The reference security managers return `UNCHANGED` in these cases.

The additional MongoDB filters keep each state transition atomic while preserving the existing update and callback flow.

## Verification
- `mvn -pl phoss-smp-backend-mongodb -am test`
- `mvn test`