### PR TITLE
Fix misleading service group exchange logging

### DIFF
--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/exchange/ServiceGroupExport.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/exchange/ServiceGroupExport.java
@@ -115,7 +115,7 @@ public final class ServiceGroupExport
     // Add Business cards only if PD integration is enabled
     if (bIncludeBusinessCards)
     {
-      LOGGER.info ("  Now exporting business groups");
+      LOGGER.info ("  Now exporting Business Cards");
 
       // Add all business cards
       final ISMPBusinessCardManager aBusinessCardMgr = SMPMetaManager.getBusinessCardMgr ();

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/exchange/ServiceGroupImport.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/exchange/ServiceGroupImport.java
@@ -556,7 +556,7 @@ public final class ServiceGroupImport
                       }
                       else
                       {
-                        aImportLogger.success (sServiceGroupID, "Error creating the new Redirect");
+                        aImportLogger.error (sServiceGroupID, "Error creating the new Redirect");
                         aImportLogger.onError (EImportSummaryAction.CREATE_REDIRECT);
                       }
                     }


### PR DESCRIPTION
## Summary

- record a failed redirect creation as an error action instead of a success action
- label business-card export progress correctly instead of referring to business groups

## Impact

When redirect persistence returned null, the import summary counted an error but the corresponding detailed action had INFO/success severity. This made the structured import report internally inconsistent and could hide the failure in consumers that inspect action levels.

## Testing

- full mvn test reactor passed with MySQL and MongoDB running