### PR TITLE
Optimize MongoDB endpoint usage aggregation

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDB.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phoss.smp.backend.mongodb.mgr;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
@@ -61,7 +62,10 @@ import com.helger.phoss.smp.domain.serviceinfo.SMPServiceInformation;
 import com.helger.phoss.smp.security.SMPCertificateHelper;
 import com.helger.photon.audit.AuditHelper;
 import com.helger.typeconvert.impl.TypeConverter;
+import com.mongodb.client.model.Accumulators;
+import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Indexes;
 import com.mongodb.client.result.DeleteResult;
 
 /**
@@ -92,6 +96,11 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
   private static final String BSON_SERVICE_DESCRIPTION = "servicedesc";
   private static final String BSON_TECHCONTACTURL = "techcontacturl";
   private static final String BSON_TECHINFOURL = "techinfourl";
+  private static final String BSON_COUNT = "count";
+
+  private static final String BSON_ENDPOINTS_PATH = BSON_PROCESSES + "." + BSON_ENDPOINTS;
+  private static final String BSON_ENDPOINT_REFERENCE_PATH = BSON_ENDPOINTS_PATH + "." + BSON_ENDPOINT_REFERENCE;
+  private static final String BSON_TRANSPORT_PROFILE_PATH = BSON_ENDPOINTS_PATH + "." + BSON_TRANSPORT_PROFILE;
 
   private final IIdentifierFactory m_aIdentifierFactory;
   private final CallbackList <ISMPServiceInformationCallback> m_aCBs = new CallbackList <> ();
@@ -100,6 +109,10 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
   {
     super ("smp-serviceinfo");
     m_aIdentifierFactory = aIdentifierFactory;
+    getCollection ().createIndex (Indexes.ascending (BSON_ID));
+    getCollection ().createIndex (Indexes.ascending (BSON_SERVICE_GROUP_ID));
+    getCollection ().createIndex (Indexes.ascending (BSON_ENDPOINT_REFERENCE_PATH));
+    getCollection ().createIndex (Indexes.ascending (BSON_TRANSPORT_PROFILE_PATH));
   }
 
   @NonNull
@@ -526,19 +539,11 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
   @Nonnegative
   public long getEndpointCount ()
   {
-    long nCount = 0;
-    for (final Document aDoc : getCollection ().find ())
-    {
-      final List <Document> aProcesses = aDoc.getList (BSON_PROCESSES, Document.class);
-      if (aProcesses != null)
-        for (final Document aProcess : aProcesses)
-        {
-          final List <Document> aEndpoints = aProcess.getList (BSON_ENDPOINTS, Document.class);
-          if (aEndpoints != null)
-            nCount += aEndpoints.size ();
-        }
-    }
-    return nCount;
+    final Document aResult = getCollection ().aggregate (Arrays.asList (Aggregates.unwind ("$" + BSON_PROCESSES),
+                                                                        Aggregates.unwind ("$" + BSON_ENDPOINTS_PATH),
+                                                                        Aggregates.count ()))
+                                             .first ();
+    return aResult == null ? 0 : ((Number) aResult.get (BSON_COUNT)).longValue ();
   }
 
   @NonNull
@@ -546,25 +551,26 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
   public ICommonsMap <String, IEndpointUsageInfo> getEndpointURLUsageMap ()
   {
     final ICommonsMap <String, IEndpointUsageInfo> ret = new CommonsHashMap <> ();
-    for (final Document aDoc : getCollection ().find ())
+    final Document aGroupID = new Document (BSON_ENDPOINT_REFERENCE, "$" + BSON_ENDPOINT_REFERENCE_PATH).append (BSON_SERVICE_GROUP_ID,
+                                                                                                                   "$" + BSON_SERVICE_GROUP_ID);
+    for (final Document aDoc : getCollection ().aggregate (Arrays.asList (Aggregates.unwind ("$" + BSON_PROCESSES),
+                                                                          Aggregates.unwind ("$" + BSON_ENDPOINTS_PATH),
+                                                                          Aggregates.group (aGroupID,
+                                                                                            Accumulators.sum (BSON_COUNT,
+                                                                                                              1))))
+                                                .allowDiskUse (true))
     {
-      final String sServiceGroupID = aDoc.getString (BSON_SERVICE_GROUP_ID);
-      final List <Document> aProcesses = aDoc.getList (BSON_PROCESSES, Document.class);
-      if (aProcesses != null)
-        for (final Document aProcess : aProcesses)
-        {
-          final List <Document> aEndpoints = aProcess.getList (BSON_ENDPOINTS, Document.class);
-          if (aEndpoints != null)
-            for (final Document aEndpoint : aEndpoints)
-            {
-              final String sURL = aEndpoint.getString (BSON_ENDPOINT_REFERENCE);
-              if (StringHelper.isNotEmpty (sURL))
-              {
-                final IEndpointUsageInfo aInfo = ret.computeIfAbsent (sURL, k -> new EndpointUsageInfo ());
-                ((EndpointUsageInfo) aInfo).incrementForServiceGroupID (sServiceGroupID);
-              }
-            }
-        }
+      final Document aID = aDoc.get ("_id", Document.class);
+      final String sURL = aID.getString (BSON_ENDPOINT_REFERENCE);
+      if (StringHelper.isNotEmpty (sURL))
+      {
+        final String sServiceGroupID = aID.getString (BSON_SERVICE_GROUP_ID);
+        final EndpointUsageInfo aInfo = (EndpointUsageInfo) ret.computeIfAbsent (sURL,
+                                                                                 k -> new EndpointUsageInfo ());
+        final int nCount = ((Number) aDoc.get (BSON_COUNT)).intValue ();
+        for (int i = 0; i < nCount; ++i)
+          aInfo.incrementForServiceGroupID (sServiceGroupID);
+      }
     }
     return ret;
   }
@@ -574,22 +580,24 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
   public ICommonsMap <String, IEndpointUsageInfo> getEndpointCertificateUsageMap ()
   {
     final ICommonsMap <String, IEndpointUsageInfo> ret = new CommonsHashMap <> ();
-    for (final Document aDoc : getCollection ().find ())
+    final String sCertificatePath = BSON_ENDPOINTS_PATH + "." + BSON_CERTIFICATE;
+    final Document aGroupID = new Document (BSON_CERTIFICATE, "$" + sCertificatePath).append (BSON_SERVICE_GROUP_ID,
+                                                                                               "$" + BSON_SERVICE_GROUP_ID);
+    for (final Document aDoc : getCollection ().aggregate (Arrays.asList (Aggregates.unwind ("$" + BSON_PROCESSES),
+                                                                          Aggregates.unwind ("$" + BSON_ENDPOINTS_PATH),
+                                                                          Aggregates.group (aGroupID,
+                                                                                            Accumulators.sum (BSON_COUNT,
+                                                                                                              1))))
+                                                .allowDiskUse (true))
     {
-      final String sServiceGroupID = aDoc.getString (BSON_SERVICE_GROUP_ID);
-      final List <Document> aProcesses = aDoc.getList (BSON_PROCESSES, Document.class);
-      if (aProcesses != null)
-        for (final Document aProcess : aProcesses)
-        {
-          final List <Document> aEndpoints = aProcess.getList (BSON_ENDPOINTS, Document.class);
-          if (aEndpoints != null)
-            for (final Document aEndpoint : aEndpoints)
-            {
-              final String sNormalizedCert = SMPCertificateHelper.getNormalizedCert (aEndpoint.getString (BSON_CERTIFICATE));
-              final IEndpointUsageInfo aInfo = ret.computeIfAbsent (sNormalizedCert, k -> new EndpointUsageInfo ());
-              ((EndpointUsageInfo) aInfo).incrementForServiceGroupID (sServiceGroupID);
-            }
-        }
+      final Document aID = aDoc.get ("_id", Document.class);
+      final String sNormalizedCert = SMPCertificateHelper.getNormalizedCert (aID.getString (BSON_CERTIFICATE));
+      final String sServiceGroupID = aID.getString (BSON_SERVICE_GROUP_ID);
+      final EndpointUsageInfo aInfo = (EndpointUsageInfo) ret.computeIfAbsent (sNormalizedCert,
+                                                                               k -> new EndpointUsageInfo ());
+      final int nCount = ((Number) aDoc.get (BSON_COUNT)).intValue ();
+      for (int i = 0; i < nCount; ++i)
+        aInfo.incrementForServiceGroupID (sServiceGroupID);
     }
     return ret;
   }
@@ -602,12 +610,10 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
     ValueEnforcer.notNull (sOldURL, "OldURL");
     ValueEnforcer.notNull (sNewURL, "NewURL");
 
-    // Count matching endpoints before the update via aggregation
-    final String sEndpointRefPath = BSON_PROCESSES + "." + BSON_ENDPOINTS + "." + BSON_ENDPOINT_REFERENCE;
     long nEndpointsChanged = 0;
 
     // Find all documents that have matching endpoints
-    Bson aFilter = Filters.eq (sEndpointRefPath, sOldURL);
+    Bson aFilter = Filters.eq (BSON_ENDPOINT_REFERENCE_PATH, sOldURL);
     if (aServiceGroupID != null)
       aFilter = Filters.and (aFilter, Filters.eq (BSON_SERVICE_GROUP_ID, aServiceGroupID.getURIEncoded ()));
 
@@ -681,7 +687,8 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
       return false;
 
     // As simple as it can be
-    return getCollection ().find (Filters.eq (BSON_PROCESSES + "." + BSON_ENDPOINTS + "." + BSON_TRANSPORT_PROFILE,
-                                              sTransportProfileID)).iterator ().hasNext ();
+    return getCollection ().find (Filters.eq (BSON_TRANSPORT_PROFILE_PATH, sTransportProfileID))
+                           .iterator ()
+                           .hasNext ();
   }
 }

--- a/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDBTest.java
+++ b/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDBTest.java
@@ -17,9 +17,11 @@
 package com.helger.phoss.smp.backend.mongodb.mgr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Rule;
@@ -36,6 +38,7 @@ import com.helger.phoss.smp.backend.mongodb.SMPServerMongoDBTestRule;
 import com.helger.phoss.smp.domain.SMPMetaManager;
 import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroup;
 import com.helger.phoss.smp.domain.servicegroup.ISMPServiceGroupManager;
+import com.helger.phoss.smp.domain.serviceinfo.IEndpointUsageInfo;
 import com.helger.phoss.smp.domain.serviceinfo.ISMPServiceInformation;
 import com.helger.phoss.smp.domain.serviceinfo.ISMPServiceInformationCallback;
 import com.helger.phoss.smp.domain.serviceinfo.ISMPServiceInformationManager;
@@ -43,6 +46,7 @@ import com.helger.phoss.smp.domain.serviceinfo.SMPEndpoint;
 import com.helger.phoss.smp.domain.serviceinfo.SMPProcess;
 import com.helger.phoss.smp.domain.serviceinfo.SMPServiceInformation;
 import com.helger.phoss.smp.exception.SMPServerException;
+import com.helger.phoss.smp.security.SMPCertificateHelper;
 import com.helger.photon.security.CSecurity;
 
 /**
@@ -52,28 +56,161 @@ import com.helger.photon.security.CSecurity;
  */
 public final class SMPServiceInformationManagerMongoDBTest
 {
+  private static final String TRANSPORT_PROFILE = "mongodb-test-transport-profile";
+
   @Rule
   public final TestRule m_aRule = new SMPServerMongoDBTestRule ();
+
+  private static SMPEndpoint _createEndpoint (final String sID,
+                                               final String sEndpointReference,
+                                               final String sCertificate)
+  {
+    return new SMPEndpoint (sID,
+                            TRANSPORT_PROFILE,
+                            sEndpointReference,
+                            false,
+                            null,
+                            null,
+                            null,
+                            sCertificate,
+                            null,
+                            null,
+                            null,
+                            null);
+  }
+
+  private static SMPServiceInformation _createServiceInformation (final IParticipantIdentifier aPI,
+                                                                  final IDocumentTypeIdentifier aDocTypeID,
+                                                                  final IProcessIdentifier aProcessID,
+                                                                  final String sExtension,
+                                                                  final SMPEndpoint... aEndpoints)
+  {
+    final SMPProcess aProcess = new SMPProcess (aProcessID, new CommonsArrayList <> (aEndpoints), null);
+    return new SMPServiceInformation (aPI, aDocTypeID, new CommonsArrayList <> (aProcess), sExtension);
+  }
 
   private static SMPServiceInformation _createServiceInformation (final IParticipantIdentifier aPI,
                                                                   final IDocumentTypeIdentifier aDocTypeID,
                                                                   final IProcessIdentifier aProcessID,
                                                                   final String sExtension)
   {
-    final SMPEndpoint aEndpoint = new SMPEndpoint ("mongodb-callback-endpoint",
-                                                   "mongodb-callback-transport-profile",
-                                                   "https://example.org/as4",
-                                                   false,
-                                                   null,
-                                                   null,
-                                                   null,
-                                                   null,
-                                                   null,
-                                                   null,
-                                                   null,
-                                                   null);
-    final SMPProcess aProcess = new SMPProcess (aProcessID, new CommonsArrayList <> (aEndpoint), null);
-    return new SMPServiceInformation (aPI, aDocTypeID, new CommonsArrayList <> (aProcess), sExtension);
+    return _createServiceInformation (aPI,
+                                      aDocTypeID,
+                                      aProcessID,
+                                      sExtension,
+                                      _createEndpoint ("mongodb-callback-endpoint", "https://example.org/as4", null));
+  }
+
+  @Test
+  public void testEndpointUsageAggregation () throws SMPServerException
+  {
+    final IIdentifierFactory aIdentifierFactory = SMPMetaManager.getIdentifierFactory ();
+    final ISMPServiceGroupManager aServiceGroupMgr = SMPMetaManager.getServiceGroupMgr ();
+    final ISMPServiceInformationManager aServiceInformationMgr = SMPMetaManager.getServiceInformationMgr ();
+
+    final IParticipantIdentifier aPI1 = aIdentifierFactory.createParticipantIdentifier (PeppolIdentifierHelper.DEFAULT_PARTICIPANT_SCHEME,
+                                                                                         "0088:mongodb-usage-1");
+    final IParticipantIdentifier aPI2 = aIdentifierFactory.createParticipantIdentifier (PeppolIdentifierHelper.DEFAULT_PARTICIPANT_SCHEME,
+                                                                                         "0088:mongodb-usage-2");
+    final IDocumentTypeIdentifier aDocTypeID1 = aIdentifierFactory.createDocumentTypeIdentifier (PeppolIdentifierHelper.DOCUMENT_TYPE_SCHEME_BUSDOX_DOCID_QNS,
+                                                                                                  "xml::xml##mongodb-usage-1::1");
+    final IDocumentTypeIdentifier aDocTypeID2 = aIdentifierFactory.createDocumentTypeIdentifier (PeppolIdentifierHelper.DOCUMENT_TYPE_SCHEME_BUSDOX_DOCID_QNS,
+                                                                                                  "xml::xml##mongodb-usage-2::1");
+    final IProcessIdentifier aProcessID = aIdentifierFactory.createProcessIdentifier (PeppolIdentifierHelper.DEFAULT_PROCESS_SCHEME,
+                                                                                       "mongodb-usage");
+    assertNotNull (aPI1);
+    assertNotNull (aPI2);
+    assertNotNull (aDocTypeID1);
+    assertNotNull (aDocTypeID2);
+    assertNotNull (aProcessID);
+
+    aServiceGroupMgr.deleteSMPServiceGroupNoEx (aPI1, true);
+    aServiceGroupMgr.deleteSMPServiceGroupNoEx (aPI2, true);
+
+    final long nEndpointCountBefore = aServiceInformationMgr.getEndpointCount ();
+    final IEndpointUsageInfo aEmptyCertUsageBefore = aServiceInformationMgr.getEndpointCertificateUsageMap ().get ("");
+    final int nEmptyCertEndpointCountBefore = aEmptyCertUsageBefore == null ? 0 : aEmptyCertUsageBefore.getEndpointCount ();
+    final int nEmptyCertServiceGroupCountBefore = aEmptyCertUsageBefore == null ? 0 : aEmptyCertUsageBefore.getServiceGroupCount ();
+
+    final String sSharedURL = "https://mongodb-usage.example/shared";
+    final String sUniqueURL = "https://mongodb-usage.example/unique";
+    final String sCertPEM = "-----BEGIN CERTIFICATE-----\nQUJD\n-----END CERTIFICATE-----";
+    final String sCertPlain = "QUJD";
+    final String sOtherCert = "REVG";
+    final String sNormalizedCert = SMPCertificateHelper.getNormalizedCert (sCertPEM);
+    assertEquals (sNormalizedCert, SMPCertificateHelper.getNormalizedCert (sCertPlain));
+
+    try
+    {
+      assertNotNull (aServiceGroupMgr.createSMPServiceGroup (CSecurity.USER_ADMINISTRATOR_ID,
+                                                             aPI1,
+                                                             null,
+                                                             null,
+                                                             false));
+      assertNotNull (aServiceGroupMgr.createSMPServiceGroup (CSecurity.USER_ADMINISTRATOR_ID,
+                                                             aPI2,
+                                                             null,
+                                                             null,
+                                                             false));
+
+      assertTrue (aServiceInformationMgr.mergeSMPServiceInformation (_createServiceInformation (aPI1,
+                                                                                                 aDocTypeID1,
+                                                                                                 aProcessID,
+                                                                                                 null,
+                                                                                                 _createEndpoint ("mongodb-usage-1",
+                                                                                                                  sSharedURL,
+                                                                                                                  sCertPEM),
+                                                                                                 _createEndpoint ("mongodb-usage-2",
+                                                                                                                  sSharedURL,
+                                                                                                                  sCertPlain),
+                                                                                                 _createEndpoint ("mongodb-usage-3",
+                                                                                                                  sUniqueURL,
+                                                                                                                  null)))
+                                        .isSuccess ());
+      assertTrue (aServiceInformationMgr.mergeSMPServiceInformation (_createServiceInformation (aPI2,
+                                                                                                 aDocTypeID2,
+                                                                                                 aProcessID,
+                                                                                                 null,
+                                                                                                 _createEndpoint ("mongodb-usage-4",
+                                                                                                                  sSharedURL,
+                                                                                                                  sCertPlain),
+                                                                                                 _createEndpoint ("mongodb-usage-5",
+                                                                                                                  null,
+                                                                                                                  sOtherCert),
+                                                                                                 _createEndpoint ("mongodb-usage-6",
+                                                                                                                  "",
+                                                                                                                  null)))
+                                        .isSuccess ());
+
+      assertEquals (nEndpointCountBefore + 6, aServiceInformationMgr.getEndpointCount ());
+
+      final var aURLUsage = aServiceInformationMgr.getEndpointURLUsageMap ();
+      final IEndpointUsageInfo aSharedURLUsage = aURLUsage.get (sSharedURL);
+      assertNotNull (aSharedURLUsage);
+      assertEquals (3, aSharedURLUsage.getEndpointCount ());
+      assertEquals (2, aSharedURLUsage.getServiceGroupCount ());
+      assertEquals (new CommonsArrayList <> (aPI1.getURIEncoded (), aPI2.getURIEncoded ()),
+                    aSharedURLUsage.getServiceGroupIDsSorted (Comparator.naturalOrder ()));
+      assertEquals (1, aURLUsage.get (sUniqueURL).getEndpointCount ());
+      assertFalse (aURLUsage.containsKey (""));
+
+      final var aCertUsage = aServiceInformationMgr.getEndpointCertificateUsageMap ();
+      final IEndpointUsageInfo aNormalizedCertUsage = aCertUsage.get (sNormalizedCert);
+      assertNotNull (aNormalizedCertUsage);
+      assertEquals (3, aNormalizedCertUsage.getEndpointCount ());
+      assertEquals (2, aNormalizedCertUsage.getServiceGroupCount ());
+      assertEquals (1, aCertUsage.get (SMPCertificateHelper.getNormalizedCert (sOtherCert)).getEndpointCount ());
+
+      final IEndpointUsageInfo aEmptyCertUsageAfter = aCertUsage.get ("");
+      assertNotNull (aEmptyCertUsageAfter);
+      assertEquals (nEmptyCertEndpointCountBefore + 2, aEmptyCertUsageAfter.getEndpointCount ());
+      assertEquals (nEmptyCertServiceGroupCountBefore + 2, aEmptyCertUsageAfter.getServiceGroupCount ());
+    }
+    finally
+    {
+      aServiceGroupMgr.deleteSMPServiceGroupNoEx (aPI1, true);
+      aServiceGroupMgr.deleteSMPServiceGroupNoEx (aPI2, true);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- calculate the total endpoint count inside MongoDB
- group endpoint URL and certificate usage in aggregation pipelines instead of loading every full service-information document into Java
- allow disk use for large aggregation workloads
- add indexes for service-information IDs, service groups, endpoint references, and transport profiles
- cover duplicate URLs, normalized certificates, missing values, counts, and distinct service groups with a MongoDB integration test

## Why

The endpoint administration pages currently transfer and deserialize every complete MongoDB service-information document just to extract endpoint counts and a few endpoint fields. This also transfers unrelated process, certificate, description, contact, and extension data. With large installations such as the 54,500-endpoint case in #333, that work can make the endpoint pages time out.

The new pipelines keep the scan and grouping in MongoDB and return only a scalar count or compact usage groups, while preserving the existing URL filtering and certificate-normalization semantics.

## Testing

- `mvn -pl phoss-smp-backend-mongodb -am test`
- `mvn --batch-mode --quiet install`

Fixes #333