### PR TITLE
Prevent Service Group export filename collisions

### DIFF
--- a/phoss-smp-backend-xml/src/test/java/com/helger/phoss/smp/exchange/ServiceGroupExportJobFuncTest.java
+++ b/phoss-smp-backend-xml/src/test/java/com/helger/phoss/smp/exchange/ServiceGroupExportJobFuncTest.java
@@ -15,6 +15,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +47,19 @@ public final class ServiceGroupExportJobFuncTest
 {
   @Rule
   public final TestRule m_aTestRule = new SMPServerTestRule ();
+
+  @Test
+  public void testExportFilenamesAreUnique ()
+  {
+    final Set <String> aFilenames = new HashSet <> ();
+    for (int i = 0; i < 100; ++i)
+    {
+      final String sFilename = ServiceGroupExportJob.createExportFilename ();
+      assertTrue (sFilename.startsWith (ServiceGroupExportJob.EXPORT_FILENAME_PREFIX));
+      assertTrue (sFilename.endsWith (ServiceGroupExportJob.EXPORT_FILENAME_EXTENSION));
+      assertTrue ("Duplicate export filename: " + sFilename, aFilenames.add (sFilename));
+    }
+  }
 
   @Test
   public void testExportToFile () throws SMPServerException

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/exchange/ServiceGroupExportJob.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/exchange/ServiceGroupExportJob.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -101,13 +102,17 @@ public class ServiceGroupExportJob extends AbstractLongRunningJobRunnable
   }
 
   /**
-   * @return The name of the export file to be created now. Never <code>null</code> nor empty.
+   * @return The unique name of the export file to be created now. Never <code>null</code> nor empty.
    */
   @NonNull
   @Nonempty
   public static String createExportFilename ()
   {
-    return EXPORT_FILENAME_PREFIX + PDTIOHelper.getCurrentLocalDateTimeForFilename () + EXPORT_FILENAME_EXTENSION;
+    return EXPORT_FILENAME_PREFIX +
+           PDTIOHelper.getCurrentLocalDateTimeForFilename () +
+           "-" +
+           UUID.randomUUID ().toString () +
+           EXPORT_FILENAME_EXTENSION;
   }
 
   /**


### PR DESCRIPTION
## Summary
- retain timestamped Service Group export filenames and add a UUID suffix
- prevent same-second export jobs from writing to the same path
- add a regression test that generates 100 filenames in one burst

## Why
The existing filename contains only a second-precision timestamp. Sequential fast exports, or separate SMP replicas sharing the export directory, can therefore select the same path. The per-process single-run lock does not coordinate across replicas, so one export may overwrite or interleave with another and multiple job records may reference the same file.

The UUID suffix preserves the existing prefix and XML extension used by download validation and retention cleanup.

## Testing
- `mvn --batch-mode -pl phoss-smp-backend-xml -am test`
- `mvn --batch-mode --quiet install` (including SQL and MongoDB integration tests)

Follow-up to #525.