### PR TITLE
Add backend-aware readiness endpoint

### DIFF
--- a/phoss-smp-webapp-mongodb/src/main/java/com/helger/phoss/smp/mongodb/status/SMPMongoDBReadyProviderExtensionSPI.java
+++ b/phoss-smp-webapp-mongodb/src/main/java/com/helger/phoss/smp/mongodb/status/SMPMongoDBReadyProviderExtensionSPI.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.mongodb.status;
+
+import com.helger.annotation.style.IsSPIImplementation;
+import com.helger.phoss.smp.backend.mongodb.MongoClientSingleton;
+import com.helger.phoss.smp.ready.ISMPReadyProviderExtensionSPI;
+
+/**
+ * MongoDB-specific readiness check using the live cluster writable state.
+ *
+ * @author vinit-thummar
+ * @since 8.3.1
+ */
+@IsSPIImplementation
+public class SMPMongoDBReadyProviderExtensionSPI implements ISMPReadyProviderExtensionSPI
+{
+  public boolean isReady ()
+  {
+    return MongoClientSingleton.isDBWritable ();
+  }
+}

--- a/phoss-smp-webapp-mongodb/src/main/resources/META-INF/services/com.helger.phoss.smp.ready.ISMPReadyProviderExtensionSPI
+++ b/phoss-smp-webapp-mongodb/src/main/resources/META-INF/services/com.helger.phoss.smp.ready.ISMPReadyProviderExtensionSPI
@@ -1,0 +1,1 @@
+com.helger.phoss.smp.mongodb.status.SMPMongoDBReadyProviderExtensionSPI

--- a/phoss-smp-webapp-mongodb/src/main/webapp/WEB-INF/web.xml
+++ b/phoss-smp-webapp-mongodb/src/main/webapp/WEB-INF/web.xml
@@ -52,6 +52,15 @@
     <servlet-name>SMPStatusServlet</servlet-name>
     <url-pattern>/smp-status/*</url-pattern>
   </servlet-mapping>
+
+  <servlet>
+    <servlet-name>SMPReadyServlet</servlet-name>
+    <servlet-class>com.helger.phoss.smp.servlet.SMPReadyServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>SMPReadyServlet</servlet-name>
+    <url-pattern>/smp-ready/*</url-pattern>
+  </servlet-mapping>
   
   <!-- UI stuff -->
 

--- a/phoss-smp-webapp-sql/src/main/java/com/helger/phoss/smp/sql/status/SMPSQLStatusProviderExtensionSPI.java
+++ b/phoss-smp-webapp-sql/src/main/java/com/helger/phoss/smp/sql/status/SMPSQLStatusProviderExtensionSPI.java
@@ -31,6 +31,7 @@ import com.helger.db.jdbc.ConnectionFromDataSource;
 import com.helger.db.jdbc.IHasConnection;
 import com.helger.phoss.smp.backend.sql.SMPDataSourceSingleton;
 import com.helger.phoss.smp.backend.sql.SMPJdbcConfiguration;
+import com.helger.phoss.smp.ready.ISMPReadyProviderExtensionSPI;
 import com.helger.phoss.smp.status.ISMPStatusProviderExtensionSPI;
 
 /**
@@ -40,7 +41,7 @@ import com.helger.phoss.smp.status.ISMPStatusProviderExtensionSPI;
  * @since 5.4.0
  */
 @IsSPIImplementation
-public class SMPSQLStatusProviderExtensionSPI implements ISMPStatusProviderExtensionSPI
+public class SMPSQLStatusProviderExtensionSPI implements ISMPStatusProviderExtensionSPI, ISMPReadyProviderExtensionSPI
 {
   private static final Logger LOGGER = LoggerFactory.getLogger (SMPSQLStatusProviderExtensionSPI.class);
 
@@ -70,6 +71,11 @@ public class SMPSQLStatusProviderExtensionSPI implements ISMPStatusProviderExten
       // Close connection again (if necessary)
       JDBCHelper.close (aConnection);
     }
+  }
+
+  public boolean isReady ()
+  {
+    return _isDBConnectionPossible ();
   }
 
   @NonNull

--- a/phoss-smp-webapp-sql/src/main/resources/META-INF/services/com.helger.phoss.smp.ready.ISMPReadyProviderExtensionSPI
+++ b/phoss-smp-webapp-sql/src/main/resources/META-INF/services/com.helger.phoss.smp.ready.ISMPReadyProviderExtensionSPI
@@ -1,0 +1,1 @@
+com.helger.phoss.smp.sql.status.SMPSQLStatusProviderExtensionSPI

--- a/phoss-smp-webapp-sql/src/main/webapp/WEB-INF/web.xml
+++ b/phoss-smp-webapp-sql/src/main/webapp/WEB-INF/web.xml
@@ -52,6 +52,15 @@
     <servlet-name>SMPStatusServlet</servlet-name>
     <url-pattern>/smp-status/*</url-pattern>
   </servlet-mapping>
+
+  <servlet>
+    <servlet-name>SMPReadyServlet</servlet-name>
+    <servlet-class>com.helger.phoss.smp.servlet.SMPReadyServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>SMPReadyServlet</servlet-name>
+    <url-pattern>/smp-ready/*</url-pattern>
+  </servlet-mapping>
   
   <!-- UI stuff -->
 

--- a/phoss-smp-webapp-xml/src/main/webapp/WEB-INF/web.xml
+++ b/phoss-smp-webapp-xml/src/main/webapp/WEB-INF/web.xml
@@ -52,6 +52,15 @@
     <servlet-name>SMPStatusServlet</servlet-name>
     <url-pattern>/smp-status/*</url-pattern>
   </servlet-mapping>
+
+  <servlet>
+    <servlet-name>SMPReadyServlet</servlet-name>
+    <servlet-class>com.helger.phoss.smp.servlet.SMPReadyServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>SMPReadyServlet</servlet-name>
+    <url-pattern>/smp-ready/*</url-pattern>
+  </servlet-mapping>
   
   <!-- UI stuff -->
 

--- a/phoss-smp-webapp-xml/src/test/java/com/helger/phoss/smp/servlet/SMPReadyServletTest.java
+++ b/phoss-smp-webapp-xml/src/test/java/com/helger/phoss/smp/servlet/SMPReadyServletTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.helger.io.resource.FileSystemResource;
+import com.helger.phoss.smp.mock.SMPServerRESTTestRule;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Test class for {@link SMPReadyServlet}.
+ *
+ * @author vinit-thummar
+ */
+public final class SMPReadyServletTest
+{
+  @Rule
+  public final SMPServerRESTTestRule m_aRule = new SMPServerRESTTestRule (new FileSystemResource ("src/test/resources/test-smp-server-xml-peppol.properties"));
+
+  @Test
+  public void testXMLBackendIsReady ()
+  {
+    try (final Client aClient = ClientBuilder.newClient ();
+         final Response aResponse = aClient.target (m_aRule.getFullURL ()).path (SMPReadyServlet.SERVLET_DEFAULT_NAME).request ().get ())
+    {
+      assertEquals (200, aResponse.getStatus ());
+      assertTrue (MediaType.APPLICATION_JSON_TYPE.isCompatible (aResponse.getMediaType ()));
+      assertEquals ("{\"ready\":true}", aResponse.readEntity (String.class));
+    }
+  }
+}

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ready/ISMPReadyProviderExtensionSPI.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ready/ISMPReadyProviderExtensionSPI.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.ready;
+
+import com.helger.annotation.style.IsSPIInterface;
+
+/**
+ * SPI interface for backend-specific readiness checks.
+ *
+ * @author vinit-thummar
+ * @since 8.3.1
+ */
+@FunctionalInterface
+@IsSPIInterface
+public interface ISMPReadyProviderExtensionSPI
+{
+  /**
+   * @return <code>true</code> if the backend is ready to serve requests, <code>false</code>
+   *         otherwise.
+   */
+  boolean isReady ();
+}

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ready/SMPReadyProvider.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/ready/SMPReadyProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.ready;
+
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.annotation.concurrent.ThreadSafe;
+import com.helger.base.spi.ServiceLoaderHelper;
+import com.helger.collection.commons.CommonsArrayList;
+import com.helger.collection.commons.ICommonsList;
+
+/**
+ * Evaluates all backend-specific readiness checks.
+ *
+ * @author vinit-thummar
+ * @since 8.3.1
+ */
+@ThreadSafe
+public final class SMPReadyProvider
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (SMPReadyProvider.class);
+  private static final ICommonsList <ISMPReadyProviderExtensionSPI> LIST = new CommonsArrayList <> ();
+  static
+  {
+    LIST.addAll (ServiceLoaderHelper.getAllSPIImplementations (ISMPReadyProviderExtensionSPI.class));
+    LOGGER.info ("Found " +
+                 LIST.size () +
+                 " implementation(s) of " +
+                 ISMPReadyProviderExtensionSPI.class.getSimpleName ());
+  }
+
+  private SMPReadyProvider ()
+  {}
+
+  static boolean areAllReady (@NonNull final Iterable <? extends ISMPReadyProviderExtensionSPI> aProviders)
+  {
+    for (final ISMPReadyProviderExtensionSPI aProvider : aProviders)
+      try
+      {
+        if (!aProvider.isReady ())
+          return false;
+      }
+      catch (final RuntimeException ex)
+      {
+        LOGGER.warn ("Readiness check failed", ex);
+        return false;
+      }
+    return true;
+  }
+
+  /**
+   * @return <code>true</code> if all registered backend checks report ready. If no check is
+   *         registered, the backend is considered ready. This is the intended behaviour for the
+   *         XML backend.
+   */
+  public static boolean isReady ()
+  {
+    return areAllReady (LIST);
+  }
+}

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestFilter.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/rest/SMPRestFilter.java
@@ -456,7 +456,7 @@ public class SMPRestFilter extends AbstractXFilterUnifiedResponse
     final APIPath aAPIPath = APIPath.createForFilter (aRequestScope);
 
     // Hard coded path with white listed requests
-    if (RegExHelper.stringMatchesPattern ("^/(ajax|error|favicon.ico|logout|ping|public|resbundle|robots.txt|secure|smp-cspreporting|smp-status|stream)(/.*)?$",
+    if (RegExHelper.stringMatchesPattern ("^/(ajax|error|favicon.ico|logout|ping|public|resbundle|robots.txt|secure|smp-cspreporting|smp-ready|smp-status|stream)(/.*)?$",
                                           aAPIPath.getPath ()))
     {
       // Explicitly other servlet

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/servlet/SMPReadyServlet.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/servlet/SMPReadyServlet.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.servlet;
+
+import com.helger.http.EHttpMethod;
+import com.helger.phoss.smp.app.SMPWebAppConfiguration;
+import com.helger.xservlet.AbstractXServlet;
+
+/**
+ * Servlet providing the backend-aware application readiness state.
+ *
+ * @author vinit-thummar
+ * @since 8.3.1
+ */
+public class SMPReadyServlet extends AbstractXServlet
+{
+  public static final String SERVLET_DEFAULT_NAME = "smp-ready";
+  public static final String SERVLET_DEFAULT_PATH = '/' + SERVLET_DEFAULT_NAME;
+
+  public SMPReadyServlet ()
+  {
+    handlerRegistry ().registerHandler (EHttpMethod.GET, new SMPReadyXServletHandler ());
+    if (SMPWebAppConfiguration.isHttpOptionsDisabled ())
+      handlerRegistry ().unregisterHandler (EHttpMethod.OPTIONS);
+  }
+}

--- a/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/servlet/SMPReadyXServletHandler.java
+++ b/phoss-smp-webapp/src/main/java/com/helger/phoss/smp/servlet/SMPReadyXServletHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.servlet;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.http.CHttp;
+import com.helger.json.IJsonObject;
+import com.helger.json.JsonObject;
+import com.helger.mime.CMimeType;
+import com.helger.mime.MimeType;
+import com.helger.phoss.smp.ready.SMPReadyProvider;
+import com.helger.servlet.response.UnifiedResponse;
+import com.helger.web.scope.IRequestWebScopeWithoutResponse;
+import com.helger.xservlet.handler.simple.IXServletSimpleHandler;
+
+/**
+ * Create the backend-aware readiness response as a small JSON object.
+ *
+ * @author vinit-thummar
+ * @since 8.3.1
+ */
+public class SMPReadyXServletHandler implements IXServletSimpleHandler
+{
+  private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+  public void handleRequest (@NonNull final IRequestWebScopeWithoutResponse aRequestScope,
+                             @NonNull final UnifiedResponse aUnifiedResponse) throws Exception
+  {
+    final boolean bReady = SMPReadyProvider.isReady ();
+    final IJsonObject aData = new JsonObject ();
+    aData.add ("ready", bReady);
+
+    aUnifiedResponse.disableCaching ();
+    aUnifiedResponse.setMimeType (new MimeType (CMimeType.APPLICATION_JSON).addParameter (CMimeType.PARAMETER_NAME_CHARSET,
+                                                                                          CHARSET.name ()));
+    if (!bReady)
+    {
+      aUnifiedResponse.setAllowContentOnStatusCode (true);
+      aUnifiedResponse.setStatus (CHttp.HTTP_SERVICE_UNAVAILABLE);
+    }
+    aUnifiedResponse.setContentAndCharset (aData.getAsJsonString (), CHARSET);
+  }
+}

--- a/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/ready/SMPReadyProviderTest.java
+++ b/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/ready/SMPReadyProviderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger and contributors
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phoss.smp.ready;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public final class SMPReadyProviderTest
+{
+  @Test
+  public void testReadinessAggregation ()
+  {
+    assertTrue (SMPReadyProvider.areAllReady (List.of ())); // XML backend
+    assertTrue (SMPReadyProvider.areAllReady (List.of ( () -> true, () -> true)));
+    assertFalse (SMPReadyProvider.areAllReady (List.of ( () -> true, () -> false)));
+    assertFalse (SMPReadyProvider.areAllReady (List.of ( () -> {
+      throw new IllegalStateException ("Expected test exception");
+    })));
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `/smp-ready` endpoint to the XML, SQL, and MongoDB WARs
- return HTTP 200 or 503 with a small `{"ready":true|false}` JSON response
- treat XML as always ready, reuse the SQL connection probe, and use MongoDB live writable state
- add readiness aggregation, SPI validation, and a real Jetty endpoint regression test

## Testing
- `mvn --batch-mode install`
- focused readiness aggregation test
- XML Jetty servlet test
- SQL and MongoDB SPI validation

Closes #529