### PR TITLE
Fix readiness exception test constructor selection

### DIFF
--- a/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/ready/SMPReadyProviderTest.java
+++ b/phoss-smp-webapp/src/test/java/com/helger/phoss/smp/ready/SMPReadyProviderTest.java
@@ -51,13 +51,13 @@ public final class SMPReadyProviderTest
   @Test
   public void testExceptionMeansNotReady ()
   {
-    assertFalse (SMPReadyProvider.areAllReady (new CommonsArrayList <> (() -> {
+    // Avoid selecting the CommonsArrayList constructor that accepts an Iterable
+    final ISMPReadyProviderExtensionSPI aThrowingProvider = () -> {
       throw new IllegalStateException ("Expected test exception");
-    })));
+    };
+    assertFalse (SMPReadyProvider.areAllReady (new CommonsArrayList <> (aThrowingProvider)));
     // The exception of the second check must not be swallowed either
-    assertFalse (SMPReadyProvider.areAllReady (new CommonsArrayList <> (() -> true, () -> {
-      throw new IllegalStateException ("Expected test exception");
-    })));
+    assertFalse (SMPReadyProvider.areAllReady (new CommonsArrayList <> (() -> true, aThrowingProvider)));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fix the construction of the throwing readiness provider in `SMPReadyProviderTest.testExceptionMeansNotReady`. This is a test-only follow-up to #537; production readiness behavior and timeouts are unchanged.

## Cause

The single lambda passed directly to `new CommonsArrayList<>(...)` only throws. It is therefore compatible with `Iterable.iterator()`, and Java selects the constructor taking an `Iterable`. The constructor invokes the lambda while adding its contents, so the exception escapes before `SMPReadyProvider.areAllReady()` is called.

Assign the lambda to an explicitly typed `ISMPReadyProviderExtensionSPI` and reuse it in both assertions. This selects the single-element constructor and actually tests that an exception from the first or second readiness check produces `false`.

The failure is reproducible on upstream `master` at `601153f6` and appears in [this master CI run](https://github.com/phax/phoss-smp/actions/runs/33726988103). It is also the readiness-test failure reported on #538; this PR does not include that PR's API-user changes.

## Verification

- Reproduced the original failure on unmodified upstream with Java 17: four readiness tests, one error in `testExceptionMeansNotReady`.
- After the fix, all four readiness tests pass with clean compilation on Java 21 and Java 25, and pass on Java 17.
- Inspected the compiled test to confirm the lambda implements `ISMPReadyProviderExtensionSPI` and the single-element collection constructor is selected.
- Full Java 17 Maven reactor (`clean verify`) passes for all nine modules, including the XML, SQL, and MongoDB webapps, against disposable MySQL and MongoDB instances: 124 tests reported, zero failures/errors, three existing skipped tests.

Focused test command:

```sh
mvn --batch-mode -pl phoss-smp-webapp -am \
  -Dtest=SMPReadyProviderTest -Dsurefire.failIfNoSpecifiedTests=false clean test
```

Full build command (database ports point to the disposable local instances):

```sh
mvn --batch-mode \
  '-Djdbc.url=jdbc:mysql://127.0.0.1:13306/smp?useUnicode=true&serverTimezone=UTC&allowPublicKeyRetrieval=true&useSSL=false' \
  -Dmongodb.connectionstring=mongodb://127.0.0.1:37017 clean verify
```
