### PR TITLE
Fix MongoDB case-insensitive email lookup matching substrings

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/security/UserManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/security/UserManagerMongoDB.java
@@ -301,7 +301,7 @@ public class UserManagerMongoDB extends AbstractBusinessObjectManagerMongoDB <IU
       return null;
 
     // Use case-insensitive RegEx for case-insensitive comparison
-    return findFirst (Filters.regex (BSON_USER_EMAIL, Pattern.quote (sEmailAddress), "i"));
+    return findFirst (Filters.regex (BSON_USER_EMAIL, "^" + Pattern.quote (sEmailAddress) + "$", "i"));
   }
 
   @Override

--- a/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/security/UserManagerMongoDBTest.java
+++ b/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/security/UserManagerMongoDBTest.java
@@ -167,6 +167,7 @@ public final class UserManagerMongoDBTest
       assertEquals (aUser, aUserMgr.getUserOfLoginName ("UserMgrTest"));
       assertEquals (aUser, aUserMgr.getUserOfEmailAddress ("usermgr@smp.localhost"));
       assertEquals (aUser, aUserMgr.getUserOfEmailAddressIgnoreCase ("UserMgr@sMp.lOcalHost"));
+      assertNull (aUserMgr.getUserOfEmailAddressIgnoreCase ("sermgr@smp.localhost"));
 
       assertNull (aUserMgr.getUserOfID ("im Not Here"));
       assertNull (aUserMgr.getUserOfLoginName ("im Not Here"));


### PR DESCRIPTION
## Summary

- make the MongoDB case-insensitive email lookup require an exact match
- keep the email value regex-escaped while anchoring both ends
- add a regression assertion for a partial local-part match

## Problem

`UserManagerMongoDB.getUserOfEmailAddressIgnoreCase` used an unanchored regular expression. As a result, looking up `sermgr@smp.localhost` could return the user whose stored address is `usermgr@smp.localhost`.

The in-memory and JDBC user managers use exact case-insensitive equality, so the MongoDB implementation should follow the same contract.

## Verification

- the new regression assertion fails on the unmodified implementation
- `mvn --batch-mode clean verify`
- all 9 reactor modules succeeded
- 150 tests reported, 3 existing skips, no failures or errors
