### PR TITLE
Fix SQL search for multilingual business card names

### DIFF
--- a/phoss-smp-backend-sql/src/test/java/com/helger/phoss/smp/backend/sql/SMPJDBCQueryHelperTest.java
+++ b/phoss-smp-backend-sql/src/test/java/com/helger/phoss/smp/backend/sql/SMPJDBCQueryHelperTest.java
@@ -141,6 +141,19 @@ public final class SMPJDBCQueryHelperTest
   }
 
   @Test
+  public void testSearchConditionBusinessCardNames ()
+  {
+    final SearchCondition aSC;
+    aSC = SMPJDBCQueryHelper.createSearchCondition (com.helger.phoss.smp.domain.businesscard.ESMPBusinessCardColumn.values (),
+                                                     "Acme");
+
+    // Service Group ID, the legacy single name and the multilingual names JSON
+    assertEquals (3, aSC.getAllParams ().size ());
+    assertTrue (aSC.getSQL ().contains ("LOWER(name) LIKE ?"));
+    assertTrue (aSC.getSQL ().contains ("LOWER(names) LIKE ?"));
+  }
+
+  @Test
   public void testLikePatternEscaping ()
   {
     // The search text is lower cased and enclosed in wildcards

--- a/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/businesscard/ESMPBusinessCardColumn.java
+++ b/phoss-smp-backend/src/main/java/com/helger/phoss/smp/domain/businesscard/ESMPBusinessCardColumn.java
@@ -45,7 +45,7 @@ public enum ESMPBusinessCardColumn implements ISMPTableColumn <ISMPBusinessCard>
    * each, so this column can be searched but not sorted by.
    */
   NAME ("name",
-        new String [] { "name" },
+        new String [] { "name", "names" },
         new String [] { "entities.names.name" },
         false,
         true,


### PR DESCRIPTION
## Summary

- include the SQL `names` JSON column in Business Card name searches
- keep the existing legacy `name` column search intact
- add a regression test for both name representations

## Problem

The SQL backend stores an entity with one unlabelled name in `name`. If it has multiple names or a language-labelled name, it stores them in the `names` JSON column and leaves `name` null.

The Business Card global search only mapped the logical name field to `name`, so these multilingual Business Cards could not be found by name. XML and MongoDB already search all entity names.

## Verification

- regression test failed before the fix with 2 predicates instead of 3
- focused SQL query-helper test passes
- MySQL smoke query finds a name stored only in `names`
- full `mvn clean verify` passes all nine modules with MySQL and MongoDB available