### PR TITLE
Handle service information replacements as updates

### DIFF
--- a/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDB.java
+++ b/phoss-smp-backend-mongodb/src/main/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDB.java
@@ -33,7 +33,6 @@ import com.helger.annotation.style.ReturnsMutableCopy;
 import com.helger.annotation.style.ReturnsMutableObject;
 import com.helger.base.callback.CallbackList;
 import com.helger.base.enforce.ValueEnforcer;
-import com.helger.base.equals.EqualsHelper;
 import com.helger.base.numeric.mutable.MutableBoolean;
 import com.helger.base.state.EChange;
 import com.helger.base.state.ESuccess;
@@ -301,29 +300,21 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
       LOGGER.debug ("mergeSMPServiceInformation (" + aSMPServiceInformationObj + ")");
 
     // Check for an update
-    boolean bChangedExisting = false;
     final ISMPServiceInformation aOldInformation = getSMPServiceInformationOfServiceGroupAndDocumentType (aSMPServiceInformation.getServiceGroupParticipantIdentifier (),
                                                                                                           aSMPServiceInformation.getDocumentTypeIdentifier ());
     if (aOldInformation != null)
     {
-      // If a service information is present, it must be the provided object!
-      // This is not true for the REST API
-      if (EqualsHelper.identityEqual (aOldInformation, aSMPServiceInformation))
-        bChangedExisting = true;
-    }
-
-    if (bChangedExisting)
-    {
-      // Edit existing
+      // Replace existing in a single database operation. In particular, REST
+      // API calls pass a newly created object rather than the stored instance.
       getCollection ().replaceOne (new Document (BSON_ID, aOldInformation.getID ()), toBson (aSMPServiceInformation));
 
       AuditHelper.onAuditModifySuccess (SMPServiceInformation.OT,
                                         "set-all",
-                                        aOldInformation.getID (),
-                                        aOldInformation.getServiceGroupID (),
-                                        aOldInformation.getDocumentTypeIdentifier ().getURIEncoded (),
-                                        aOldInformation.getAllProcesses (),
-                                        aOldInformation.getExtensions ().getExtensionsAsJsonString ());
+                                        aSMPServiceInformation.getID (),
+                                        aSMPServiceInformation.getServiceGroupID (),
+                                        aSMPServiceInformation.getDocumentTypeIdentifier ().getURIEncoded (),
+                                        aSMPServiceInformation.getAllProcesses (),
+                                        aSMPServiceInformation.getExtensions ().getExtensionsAsJsonString ());
 
       if (LOGGER.isDebugEnabled ())
         LOGGER.debug ("mergeSMPServiceInformation - success - updated");
@@ -332,33 +323,9 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
     }
     else
     {
-      // (Optionally delete the old one and) create the new one
-      boolean bRemovedOld = false;
-      if (aOldInformation != null)
-      {
-        // Delete only if present
-        final DeleteResult aDR = getCollection ().deleteOne (new Document (BSON_ID, aOldInformation.getID ()));
-        bRemovedOld = aDR.wasAcknowledged () && aDR.getDeletedCount () > 0;
-      }
-
+      // Create the new one
       if (!getCollection ().insertOne (toBson (aSMPServiceInformation)).wasAcknowledged ())
         throw new IllegalStateException ("Failed to insert into MongoDB Collection");
-
-      if (bRemovedOld)
-      {
-        AuditHelper.onAuditDeleteSuccess (SMPServiceInformation.OT,
-                                          aOldInformation.getID (),
-                                          aOldInformation.getServiceGroupID (),
-                                          aOldInformation.getDocumentTypeIdentifier ().getURIEncoded ());
-      }
-      else
-        if (aOldInformation != null)
-        {
-          AuditHelper.onAuditDeleteFailure (SMPServiceInformation.OT,
-                                            aOldInformation.getID (),
-                                            aOldInformation.getServiceGroupID (),
-                                            aOldInformation.getDocumentTypeIdentifier ().getURIEncoded ());
-        }
 
       AuditHelper.onAuditCreateSuccess (SMPServiceInformation.OT,
                                         aSMPServiceInformation.getID (),
@@ -369,10 +336,7 @@ public final class SMPServiceInformationManagerMongoDB extends AbstractManagerMo
       if (LOGGER.isDebugEnabled ())
         LOGGER.debug ("mergeSMPServiceInformation - success - created");
 
-      if (aOldInformation != null)
-        m_aCBs.forEach (x -> x.onSMPServiceInformationUpdated (aSMPServiceInformation));
-      else
-        m_aCBs.forEach (x -> x.onSMPServiceInformationCreated (aSMPServiceInformation));
+      m_aCBs.forEach (x -> x.onSMPServiceInformationCreated (aSMPServiceInformation));
     }
     return ESuccess.SUCCESS;
   }

--- a/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDBTest.java
+++ b/phoss-smp-backend-mongodb/src/test/java/com/helger/phoss/smp/backend/mongodb/mgr/SMPServiceInformationManagerMongoDBTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 
 import com.helger.collection.commons.CommonsArrayList;
+import com.helger.collection.commons.ICommonsList;
 import com.helger.peppolid.IDocumentTypeIdentifier;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.IProcessIdentifier;
@@ -47,6 +48,9 @@ import com.helger.phoss.smp.domain.serviceinfo.SMPProcess;
 import com.helger.phoss.smp.domain.serviceinfo.SMPServiceInformation;
 import com.helger.phoss.smp.exception.SMPServerException;
 import com.helger.phoss.smp.security.SMPCertificateHelper;
+import com.helger.photon.audit.AuditHelper;
+import com.helger.photon.audit.EAuditActionType;
+import com.helger.photon.audit.IAuditor;
 import com.helger.photon.security.CSecurity;
 
 /**
@@ -208,7 +212,7 @@ public final class SMPServiceInformationManagerMongoDBTest
   }
 
   @Test
-  public void testMergeReplacementFiresUpdateCallback () throws SMPServerException
+  public void testMergeReplacementUsesUpdateSemantics () throws SMPServerException
   {
     final IIdentifierFactory aIdentifierFactory = SMPMetaManager.getIdentifierFactory ();
     final ISMPServiceGroupManager aServiceGroupMgr = SMPMetaManager.getServiceGroupMgr ();
@@ -234,6 +238,8 @@ public final class SMPServiceInformationManagerMongoDBTest
 
     final AtomicInteger aCreatedCount = new AtomicInteger ();
     final AtomicInteger aUpdatedCount = new AtomicInteger ();
+    final ICommonsList <EAuditActionType> aAuditActions = new CommonsArrayList <> ();
+    final IAuditor aOldAuditor = AuditHelper.getAuditor ();
     final ISMPServiceInformationCallback aCallback = new ISMPServiceInformationCallback ()
     {
       @Override
@@ -251,6 +257,11 @@ public final class SMPServiceInformationManagerMongoDBTest
     aServiceInformationMgr.serviceInformationCallbacks ().add (aCallback);
     try
     {
+      AuditHelper.setAuditor ((eActionType, eSuccess, aActionObjectType, sAction, aArgs) -> {
+        if (SMPServiceInformation.OT.equals (aActionObjectType))
+          aAuditActions.add (eActionType);
+      });
+
       assertTrue (aServiceInformationMgr.mergeSMPServiceInformation (_createServiceInformation (aPI,
                                                                                                 aDocTypeID,
                                                                                                 aProcessID,
@@ -258,7 +269,9 @@ public final class SMPServiceInformationManagerMongoDBTest
                                         .isSuccess ());
       assertEquals (1, aCreatedCount.get ());
       assertEquals (0, aUpdatedCount.get ());
+      assertEquals (new CommonsArrayList <> (EAuditActionType.CREATE), aAuditActions);
 
+      aAuditActions.clear ();
       assertTrue (aServiceInformationMgr.mergeSMPServiceInformation (_createServiceInformation (aPI,
                                                                                                 aDocTypeID,
                                                                                                 aProcessID,
@@ -266,9 +279,15 @@ public final class SMPServiceInformationManagerMongoDBTest
                                         .isSuccess ());
       assertEquals (1, aCreatedCount.get ());
       assertEquals (1, aUpdatedCount.get ());
+      assertEquals (new CommonsArrayList <> (EAuditActionType.MODIFY), aAuditActions);
+      assertTrue (aServiceInformationMgr.getSMPServiceInformationOfServiceGroupAndDocumentType (aPI, aDocTypeID)
+                                        .getExtensions ()
+                                        .getExtensionsAsJsonString ()
+                                        .contains ("ext2"));
     }
     finally
     {
+      AuditHelper.setAuditor (aOldAuditor);
       aServiceInformationMgr.serviceInformationCallbacks ().removeObject (aCallback);
       aServiceGroupMgr.deleteSMPServiceGroupNoEx (aPI, true);
     }

--- a/phoss-smp-backend-xml/src/main/java/com/helger/phoss/smp/backend/xml/mgr/SMPServiceInformationManagerXML.java
+++ b/phoss-smp-backend-xml/src/main/java/com/helger/phoss/smp/backend/xml/mgr/SMPServiceInformationManagerXML.java
@@ -30,7 +30,6 @@ import com.helger.annotation.style.ReturnsMutableCopy;
 import com.helger.annotation.style.ReturnsMutableObject;
 import com.helger.base.callback.CallbackList;
 import com.helger.base.enforce.ValueEnforcer;
-import com.helger.base.equals.EqualsHelper;
 import com.helger.base.numeric.mutable.MutableLong;
 import com.helger.base.state.EChange;
 import com.helger.base.state.ESuccess;
@@ -118,29 +117,21 @@ public final class SMPServiceInformationManagerXML extends
       LOGGER.debug ("mergeSMPServiceInformation (" + aSMPServiceInformationObj + ")");
 
     // Check for an update
-    boolean bChangeExisting = false;
     final SMPServiceInformation aOldInformation = (SMPServiceInformation) getSMPServiceInformationOfServiceGroupAndDocumentType (aSMPServiceInformation.getServiceGroupParticipantIdentifier (),
                                                                                                                                  aSMPServiceInformation.getDocumentTypeIdentifier ());
     if (aOldInformation != null)
     {
-      // If a service information is present, it must be the provided object!
-      // This is not true for the REST API
-      if (EqualsHelper.identityEqual (aOldInformation, aSMPServiceInformation))
-        bChangeExisting = true;
-    }
-
-    if (bChangeExisting)
-    {
-      // Edit existing
-      m_aRWLock.writeLocked (() -> { internalUpdateItem (aOldInformation); });
+      // Replace existing. In particular, REST API calls pass a newly created
+      // object rather than the stored instance.
+      m_aRWLock.writeLocked (() -> { internalUpdateItem (aSMPServiceInformation); });
 
       AuditHelper.onAuditModifySuccess (SMPServiceInformation.OT,
                                         "set-all",
-                                        aOldInformation.getID (),
-                                        aOldInformation.getServiceGroupID (),
-                                        aOldInformation.getDocumentTypeIdentifier ().getURIEncoded (),
-                                        aOldInformation.getAllProcesses (),
-                                        aOldInformation.getExtensions ().getExtensionsAsJsonString ());
+                                        aSMPServiceInformation.getID (),
+                                        aSMPServiceInformation.getServiceGroupID (),
+                                        aSMPServiceInformation.getDocumentTypeIdentifier ().getURIEncoded (),
+                                        aSMPServiceInformation.getAllProcesses (),
+                                        aSMPServiceInformation.getExtensions ().getExtensionsAsJsonString ());
 
       if (LOGGER.isDebugEnabled ())
         LOGGER.debug ("mergeSMPServiceInformation - success - updated");
@@ -149,40 +140,8 @@ public final class SMPServiceInformationManagerXML extends
     }
     else
     {
-      // (Optionally delete the old one and) create the new one
-      boolean bRemovedOld = false;
-      m_aRWLock.writeLock ().lock ();
-      try
-      {
-        if (aOldInformation != null)
-        {
-          // Delete only if present
-          final SMPServiceInformation aDeletedInformation = internalDeleteItem (aOldInformation.getID ());
-          bRemovedOld = EqualsHelper.identityEqual (aDeletedInformation, aOldInformation);
-        }
-
-        internalCreateItem (aSMPServiceInformation);
-      }
-      finally
-      {
-        m_aRWLock.writeLock ().unlock ();
-      }
-
-      if (bRemovedOld)
-      {
-        AuditHelper.onAuditDeleteSuccess (SMPServiceInformation.OT,
-                                          aOldInformation.getID (),
-                                          aOldInformation.getServiceGroupID (),
-                                          aOldInformation.getDocumentTypeIdentifier ().getURIEncoded ());
-      }
-      else
-        if (aOldInformation != null)
-        {
-          AuditHelper.onAuditDeleteFailure (SMPServiceInformation.OT,
-                                            aOldInformation.getID (),
-                                            aOldInformation.getServiceGroupID (),
-                                            aOldInformation.getDocumentTypeIdentifier ().getURIEncoded ());
-        }
+      // Create the new one
+      m_aRWLock.writeLocked (() -> { internalCreateItem (aSMPServiceInformation); });
 
       AuditHelper.onAuditCreateSuccess (SMPServiceInformation.OT,
                                         aSMPServiceInformation.getID (),
@@ -193,10 +152,7 @@ public final class SMPServiceInformationManagerXML extends
       if (LOGGER.isDebugEnabled ())
         LOGGER.debug ("mergeSMPServiceInformation - success - created");
 
-      if (aOldInformation != null)
-        m_aCBs.forEach (x -> x.onSMPServiceInformationUpdated (aSMPServiceInformation));
-      else
-        m_aCBs.forEach (x -> x.onSMPServiceInformationCreated (aSMPServiceInformation));
+      m_aCBs.forEach (x -> x.onSMPServiceInformationCreated (aSMPServiceInformation));
     }
     return ESuccess.SUCCESS;
   }

--- a/phoss-smp-backend-xml/src/test/java/com/helger/phoss/smp/backend/xml/mgr/SMPServiceInformationManagerXMLTest.java
+++ b/phoss-smp-backend-xml/src/test/java/com/helger/phoss/smp/backend/xml/mgr/SMPServiceInformationManagerXMLTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -45,6 +47,9 @@ import com.helger.phoss.smp.domain.serviceinfo.SMPProcess;
 import com.helger.phoss.smp.domain.serviceinfo.SMPServiceInformation;
 import com.helger.phoss.smp.exception.SMPServerException;
 import com.helger.phoss.smp.mock.SMPServerTestRule;
+import com.helger.photon.audit.AuditHelper;
+import com.helger.photon.audit.EAuditActionType;
+import com.helger.photon.audit.IAuditor;
 import com.helger.photon.security.CSecurity;
 import com.helger.photon.security.mgr.PhotonSecurityManager;
 import com.helger.photon.security.user.IUser;
@@ -119,6 +124,51 @@ public final class SMPServiceInformationManagerXMLTest
                                     .getAllProcesses ()
                                     .get (0)
                                     .getEndpointCount ());
+      }
+
+      {
+        // A REST-like replacement uses a different Java object and must still
+        // be handled and audited as an update.
+        final SMPEndpoint aEP = new SMPEndpoint ("epid",
+                                                 "tp",
+                                                 "http://localhost/as2-rest",
+                                                 false,
+                                                 "minauth",
+                                                 aStartDT,
+                                                 aEndDT,
+                                                 "cert",
+                                                 "sd",
+                                                 "tc",
+                                                 "ti",
+                                                 "<extep />");
+        final SMPProcess aProcess = new SMPProcess (aProcessID, new CommonsArrayList <> (aEP), "<extproc />");
+        final IAuditor aOldAuditor = AuditHelper.getAuditor ();
+        final AtomicReference <EAuditActionType> aAuditAction = new AtomicReference <> ();
+        try
+        {
+          AuditHelper.setAuditor ((eActionType, eSuccess, aActionObjectType, sAction, aArgs) -> {
+            if (SMPServiceInformation.OT.equals (aActionObjectType))
+              aAuditAction.set (eActionType);
+          });
+          assertTrue (aServiceInformationMgr.mergeSMPServiceInformation (new SMPServiceInformation (aPI,
+                                                                                                    aDocTypeID,
+                                                                                                    new CommonsArrayList <> (aProcess),
+                                                                                                    "<extsi-rest />"))
+                                            .isSuccess ());
+          assertEquals (EAuditActionType.MODIFY, aAuditAction.get ());
+        }
+        finally
+        {
+          AuditHelper.setAuditor (aOldAuditor);
+        }
+
+        assertEquals ("http://localhost/as2-rest",
+                      CollectionFind.getFirstElement (aServiceInformationMgr.getAllSMPServiceInformation ())
+                                    .getAllProcesses ()
+                                    .get (0)
+                                    .getAllEndpoints ()
+                                    .get (0)
+                                    .getEndpointReference ());
       }
 
       {


### PR DESCRIPTION
## Summary

- treat existing XML and MongoDB service information as an update even when the caller supplies a new Java object
- replace MongoDB documents in one operation instead of deleting and reinserting them
- emit one MODIFY audit entry for replacements, matching the SQL backend
- retain CREATE audit and callback semantics for first-time inserts

## Problem

mergeSMPServiceInformation used Java object identity to distinguish updates in the XML and MongoDB backends. REST requests construct a new SMPServiceInformation object, so replacing an existing record followed the delete-and-create path. This produced DELETE plus CREATE audit entries and, for MongoDB, a transient gap between two database operations. The update callback was corrected in #519, but persistence and audit semantics remained inconsistent.

## Tests

- regression test on the old implementation: expected MODIFY but received DELETE followed by CREATE
- XML replacement persistence and MODIFY audit test
- MongoDB replacement persistence, callback, and MODIFY audit test
- affected backend modules pass in the Maven reactor and in focused test runs